### PR TITLE
Follow up of PR #56

### DIFF
--- a/libexec/goenv
+++ b/libexec/goenv
@@ -117,22 +117,22 @@ case "$command" in
 -h | --help )
   exec goenv-help
   ;;
-
 * )
   if [ "$command" = "shell" ] && [ -z "${GOENV_SHELL}" ]; then
-    echo 'eval "$(goenv init -)" has not been executed'
-    echo "please read the installation instructions in the README"
-    echo "also read COMMANDS.md about the shell command"
-  else
-    command_path="$(command -v "goenv-$command" || true)"
-    [ -n "$command_path" ] || abort "no such command \`$command'"
+    echo 'eval "$(goenv init -)" has not been executed.'
+    echo "Please read the installation instructions in the README.md at github.com/syndbg/goenv"
+    echo "or run 'goenv help init' for more information"
+    exit 1
+  fi
 
-    shift 1
-    if [ "$1" = --help ]; then
-      exec goenv-help "$command"
-    else
-      exec "$command_path" "$@"
-    fi
+  command_path="$(command -v "goenv-$command" || true)"
+  [ -n "$command_path" ] || abort "no such command '$command'"
+
+  shift 1
+  if [ "$1" = --help ]; then
+    exec goenv-help "$command"
+  else
+    exec "$command_path" "$@"
   fi
   ;;
 esac

--- a/test/goenv.bats
+++ b/test/goenv.bats
@@ -96,3 +96,15 @@ OUT
   run goenv echo "GOENV_HOOK_PATH"
   assert_success "${GOENV_ROOT}/goenv.d:${BATS_TEST_DIRNAME%/*}/goenv.d:/usr/local/etc/goenv.d:/etc/goenv.d:/usr/lib/goenv/hooks"
 }
+
+@test "prints error when called with 'shell' subcommand, but `GOENV_SHELL` environment variable is not present" {
+  unset GOENV_SHELL
+  run goenv shell
+  assert_output <<'OUT'
+eval "$(goenv init -)" has not been executed.
+Please read the installation instructions in the README.md at github.com/syndbg/goenv
+or run 'goenv help init' for more information
+OUT
+
+  assert_failure
+}


### PR DESCRIPTION
Since #62 is now merged, #56 is no longer blocked.

I've made some small modifications.

```
Modify `goenv shell` when no `GOENV_SHELL`

* Return exit status 1
* Refer to README.md
* Refer to immediate help via `goenv help init`
adec84f
```
Also added a test for this case.