### PR TITLE
go.mod: add toolchain support

### DIFF
--- a/libexec/goenv
+++ b/libexec/goenv
@@ -13,8 +13,11 @@ if [ -n "$GOENV_DEBUG" ]; then
 fi
 
 abort() {
-  { if [ "$#" -eq 0 ]; then cat -
-    else echo "goenv: $*"
+  {
+    if [ "$#" -eq 0 ]; then
+      cat -
+    else
+      echo "goenv: $*"
     fi
   } >&2
   exit 1
@@ -79,7 +82,6 @@ else
 fi
 export GOENV_DIR
 
-
 shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
@@ -106,24 +108,24 @@ export GOENV_HOOK_PATH
 shopt -u nullglob
 
 if [[ -z ${@} ]] && [[ $GOENV_AUTO_INSTALL == 1 ]]; then
-    set -- "install"
+  set -- "install" $GOENV_AUTO_INSTALL_FLAGS
 fi
 
 command="$1"
 case "$command" in
-"" )
+"")
   {
     goenv---version
     goenv-help
   } | abort
   ;;
--v | --version )
+-v | --version)
   exec goenv---version
   ;;
--h | --help )
+-h | --help)
   exec goenv-help
   ;;
-* )
+*)
   if [ "$command" = "shell" ] && [ -z "${GOENV_SHELL}" ]; then
     echo 'eval "$(goenv init -)" has not been executed.'
     echo "Please read the installation instructions in the README.md at github.com/go-nv/goenv"

--- a/libexec/goenv-version-file-read
+++ b/libexec/goenv-version-file-read
@@ -11,7 +11,16 @@ if [ ! -f "$VERSION_FILE" ]; then
 fi
 
 if [[ "$(basename $VERSION_FILE)" == "go.mod" ]]; then
-  versions=($(cat $VERSION_FILE | grep -E "^go [0-9]\\.[0-9]{1,2}(beta|rc)?" | sed 's/go //'))
+  expression_prefix=""
+
+  has_toolchain=$(cat $VERSION_FILE | grep -E "^toolchain[ \\t]*"
+  if [[ -n "$has_toolchain" ]]; then
+    expression_prefix="^toolchain[ \\t]*"
+  fi
+
+  expression="${expression_prefix}go[ \\t]*[0-9]+\\.[0-9]+(beta|rc)?"
+
+  versions=($(cat $VERSION_FILE | grep -E "${expression}" | sed "s/${expression_prefix}go[ \\t]*//"))
 else
   # NOTE: Read the first non-whitespace word from the specified version file.
   # Be careful not to load it whole in case there's something crazy in it.

--- a/libexec/goenv-version-file-read
+++ b/libexec/goenv-version-file-read
@@ -13,7 +13,7 @@ fi
 if [[ "$(basename $VERSION_FILE)" == "go.mod" ]]; then
   expression_prefix=""
 
-  has_toolchain=$(cat $VERSION_FILE | grep -E "^toolchain[ \\t]*")
+  has_toolchain=$(cat $VERSION_FILE | { grep -E "^toolchain[ \\t]*" || true; })
   if [[ -n "$has_toolchain" ]]; then
     expression_prefix="^toolchain[ \\t]*"
   fi

--- a/libexec/goenv-version-file-read
+++ b/libexec/goenv-version-file-read
@@ -13,7 +13,7 @@ fi
 if [[ "$(basename $VERSION_FILE)" == "go.mod" ]]; then
   expression_prefix=""
 
-  has_toolchain=$(cat $VERSION_FILE | grep -E "^toolchain[ \\t]*"
+  has_toolchain=$(cat $VERSION_FILE | grep -E "^toolchain[ \\t]*")
   if [[ -n "$has_toolchain" ]]; then
     expression_prefix="^toolchain[ \\t]*"
   fi

--- a/test/goenv-version-file-read.bats
+++ b/test/goenv-version-file-read.bats
@@ -50,6 +50,25 @@ IN
   assert_success "1.11"
 }
 
+@test "reads go.mod file with toolchain specified in arguments that exists and is not blank" {
+  cat >go.mod <<IN
+
+module github.com/go-nv/goenv
+
+go 1.11
+
+toolchain go1.11.4
+
+require (
+	github.com/foo/bar v0.0.0-20220101000000-0123456789abcdef // indirect
+)
+
+IN
+
+  run goenv-version-file-read go.mod
+  assert_success "1.11.4"
+}
+
 @test "reads version file specified in arguments that exists and is not blank" {
   echo "1.11.1" >my-version
 


### PR DESCRIPTION
go 1.21.x introduces the idea of toolchains.

Add support for switching goenv version based on go.mod file when toolchain version is present.