### PR TITLE
feat: Allow major or minor version lookup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/libexec/goenv
+++ b/libexec/goenv
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 export -n CDPATH
+export LC_ALL=C # boost grep performance by disabling unicode
 
 if [ "$1" = "--debug" ]; then
   export GOENV_DEBUG=1
@@ -133,10 +134,16 @@ case "$command" in
     exit 1
   fi
 
-  command_path="$(command -v "goenv-$command" || true)"
-  [ -n "$command_path" ] || abort "no such command '$command'"
+  # Just a version number given (or `latest` or `system`) -> assume `goenv local $@`
+  if grep -q -E "^[0-9]+(\.[0-9]+){0,2}$" <<<"${command}" || [ "$command" == "latest" ] || [ "$command" == "system" ]; then
+    command_path="goenv-local"
+  else
+    command_path="$(command -v "goenv-$command" || true)"
+    [ -n "$command_path" ] || abort "no such command '$command'"
 
-  shift 1
+    shift 1
+  fi
+
   if [ "$1" = --help ]; then
     exec goenv-help "$command"
   else

--- a/libexec/goenv
+++ b/libexec/goenv
@@ -126,6 +126,10 @@ case "$command" in
 -h | --help)
   exec goenv-help
   ;;
+# NOTE: Provide goenv completions
+--complete)
+  exec goenv-commands
+  ;;
 *)
   if [ "$command" = "shell" ] && [ -z "${GOENV_SHELL}" ]; then
     echo 'eval "$(goenv init -)" has not been executed.'

--- a/libexec/goenv-commands
+++ b/libexec/goenv-commands
@@ -26,6 +26,16 @@ shopt -s nullglob
 
 {
   for path in "${paths[@]}"; do
+    # goenv-init uses --sh, don't output special commands then
+    if [ -z "$sh" ]; then
+      # Output special commands (plugins and version identifiers)
+      echo install
+      echo latest
+      echo system
+      echo uninstall
+      goenv-versions --bare
+    fi
+
     for command in "${path}/goenv-"*; do
       command="${command##*goenv-}"
       if [ -n "$sh" ]; then
@@ -41,4 +51,4 @@ shopt -s nullglob
       fi
     done
   done
-} | sort | uniq
+} | sort | uniq | grep -v -E '^(echo|--version|realpath\.dylib)$'

--- a/libexec/goenv-global
+++ b/libexec/goenv-global
@@ -2,21 +2,28 @@
 #
 # Summary: Set or show the global Go version
 #
-# Usage: goenv global <version>
+# Usage: goenv global [<version>]
 #
 # Sets the global Go version. You can override the global version at
 # any time by setting a directory-specific version with `goenv local'
 # or by setting the `GOENV_VERSION' environment variable.
 #
 # <version> should be a string matching a Go version known to goenv.
-# The special version string `system' will use your default system Go.
-# Run `goenv versions' for a list of available Go versions.
+# If no <version> is given, displays the global version if configured.
+# <version> `system` unsets the previous version and displays it if configured.
+# <version> `latest` sets the latest installed version (1.23.4).
+# <version> `1` sets the latest installed major version (1.23.4).
+# <version> `23` or `1.23` sets the latest installed minor version (1.23.4).
+# <version> `1.23.4` sets this installed version (1.23.4).
+# If no version can be found or no versions are installed or configured, an error message will be displayed.
+# Run `goenv versions` for a list of available Go versions.
 
 set -e
 [ -n "$GOENV_DEBUG" ] && set -x
 
 # Provide goenv completions
 if [ "$1" = "--complete" ]; then
+  echo latest
   echo system
   exec goenv-versions --bare
 fi

--- a/libexec/goenv-installed
+++ b/libexec/goenv-installed
@@ -3,17 +3,24 @@
 # Usage: goenv installed [<version>]
 #
 # Displays the installed Go version, searching for shortcuts if necessary.
-# If no version is given, `goenv installed' displays the latest installed version.
-# If version is `system`, `system` will be returned if an installed system Go can be found.
-# If version is `latest`, the latest installed Go version will be returned (1.23.4).
-# If version is `1`, the latest installed Go version of this major version will be returned (1.23.4).
-# If version is `23` or `1.23`, the latest installed patch of this minor version will be returned (1.23.4).
-# If version is `1.23.4`, the same version will be returned if that patch version is installed (1.23.4).
-# If version is not found or no versions are installed, an error message will be returned with an error code.
+# If no <version> or `latest` is given, displays the latest installed version (1.23.4).
+# <version> `system` displays `system` if an installed system Go can be found.
+# <version> `1` displays the latest installed major version (1.23.4).
+# <version> `23` or `1.23` displays the latest installed minor version (1.23.4).
+# <version> `1.23.4` displays this installed version (1.23.4).
+# If no version can be found or no versions are installed, an error message will be displayed.
+# Run `goenv versions` for a list of available Go versions.
 
 
 set -e
 [ -n "$GOENV_DEBUG" ] && set -x
+
+# Provide goenv completions
+if [ "$1" = "--complete" ]; then
+  echo latest
+  echo system
+  exec goenv-versions --bare
+fi
 
 #majors=({2,1}) # Supported Go versions: 2,1 (latest first)
 majors=({1,}) # Supported Go versions: 1 (latest first)

--- a/libexec/goenv-installed
+++ b/libexec/goenv-installed
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Summary: Display an installed Go version
+# Usage: goenv installed [<version>]
+#
+# Displays the installed Go version, searching for shortcuts if necessary.
+# If no version is given, `goenv installed' displays the latest installed version.
+# If version is `system`, `system` will be returned if an installed system Go can be found.
+# If version is `latest`, the latest installed Go version will be returned (1.23.4).
+# If version is `1`, the latest installed Go version of this major version will be returned (1.23.4).
+# If version is `23` or `1.23`, the latest installed patch of this minor version will be returned (1.23.4).
+# If version is `1.23.4`, the same version will be returned if that patch version is installed (1.23.4).
+# If version is not found or no versions are installed, an error message will be returned with an error code.
+
+
+set -e
+[ -n "$GOENV_DEBUG" ] && set -x
+
+#majors=({2,1}) # Supported Go versions: 2,1 (latest first)
+majors=({1,}) # Supported Go versions: 1 (latest first)
+
+versions() {
+  # Sort correctly (1.20.9 comes before 1.20.10)
+  goenv versions --bare | sort -V | $(type -p ggrep grep | head -1) -F "$query" || true
+}
+
+latest_version() {
+  versions | tail -1
+}
+
+latest_major() {
+  # 1 -> latest major 1.23.4
+  versions | grep -oE "^$(regex "$1")\\.[0-9]+\\.[0-9]+$" | tail -1
+}
+
+latest_minor() {
+  # 1.23 -> latest minor 1.23.4
+  versions | grep -oE "^$(regex "$1")\\.([0-9]+)$" | tail -1
+}
+
+installed() {
+  # 1.23.4 -> 1.23.4 if installed (else "")
+  versions | grep -oE "^$(regex "$1")$" || true
+}
+
+regex() {
+  echo "${1//\./\\.}"
+}
+
+
+if [ -n "$1" ]; then
+  version="$1"
+else
+  version="latest"
+fi
+
+if [ "$version" = "system" ]; then
+  if [ -n "$(GOENV_VERSION="${version}" goenv-which go 2>/dev/null)" ]; then
+    echo "system"
+    exit 0
+  else
+    echo "goenv: system version not found in PATH" >&2
+    exit 1
+  fi
+fi
+if [ "$version" = "latest" ]; then
+  LATEST_PATCH=$(latest_version)
+  if [ -n "$LATEST_PATCH" ]; then
+    echo "$LATEST_PATCH"
+    exit 0
+  else
+    echo "goenv: no versions installed" >&2
+    exit 1
+  fi
+fi
+
+# Check version=1 (major without minor and patch) => 1.23.4 (latest major version)
+# Or version=23 (minor without major and patch) => 1.23.4 (latest patch version)
+if grep -q -E "^[0-9]+(\s*)$" <<<"${version}"; then
+  for major in "${majors[@]}"; do
+    if [ "$version" = "$major" ]; then
+      LATEST_MAJOR=$(latest_major "$version")
+      if [ -n "$LATEST_MAJOR" ]; then
+        echo "$LATEST_MAJOR"
+        exit 0
+      fi
+    else
+      LATEST_MINOR=$(latest_minor "$major.$version")
+      if [ -n "$LATEST_MINOR" ]; then
+        echo "$LATEST_MINOR"
+        exit 0
+      fi
+    fi
+  done
+fi
+
+# Check version=1.23 (minor without patch) => 1.23.4 (latest patch version)
+if grep -q -E "^[0-9]+\.[0-9]+(\s*)$" <<<"${version}"; then
+  LATEST_MINOR=$(latest_minor "$version")
+  if [ -n "$LATEST_MINOR" ]; then
+    echo "$LATEST_MINOR"
+    exit 0
+  fi
+fi
+
+# Check version=1.23.4 (full version number) => 1.23.4 (installed version)
+if grep -q -E "^[0-9]+\.[0-9]+\.[0-9]+(\s*)$" <<<"${version}"; then
+  INSTALLED=$(installed "$version")
+  if [ -n "$INSTALLED" ]; then
+    echo "$INSTALLED"
+    exit 0
+  fi
+fi
+
+echo "goenv: version '${version}' not installed" >&2
+exit 1

--- a/libexec/goenv-local
+++ b/libexec/goenv-local
@@ -2,7 +2,7 @@
 #
 # Summary: Set or show the local application-specific Go version
 #
-# Usage: goenv local <version>
+# Usage: goenv local [<version>]
 #        goenv local --unset
 #
 # Sets the local application-specific Go version by writing the
@@ -16,8 +16,14 @@
 # and global versions.
 #
 # <version> should be a string matching a Go version known to goenv.
-# The special version string `system' will use your default system Go.
-# Run `goenv versions' for a list of available Go versions.
+# If no <version> is given, displays the local version if configured.
+# <version> `system` unsets the previous version and displays it if configured.
+# <version> `latest` sets the latest installed version (1.23.4).
+# <version> `1` sets the latest installed major version (1.23.4).
+# <version> `23` or `1.23` sets the latest installed minor version (1.23.4).
+# <version> `1.23.4` sets this installed version (1.23.4).
+# If no version can be found or no versions are installed or configured, an error message will be displayed.
+# Run `goenv versions` for a list of available Go versions.
 
 set -e
 [ -n "$GOENV_DEBUG" ] && set -x
@@ -25,6 +31,7 @@ set -e
 # Provide goenv completions
 if [ "$1" = "--complete" ]; then
   echo --unset
+  echo latest
   echo system
   exec goenv-versions --bare
 fi

--- a/libexec/goenv-prefix
+++ b/libexec/goenv-prefix
@@ -16,7 +16,8 @@ if [ "$1" = "--complete" ]; then
 fi
 
 versions() {
-  goenv versions --bare | $(type -p ggrep grep | head -1) -F "$query" || true
+  # Sort correctly (1.20.9 comes before 1.20.10)
+  goenv versions --bare | sort -V | $(type -p ggrep grep | head -1) -F "$query" || true
 }
 
 latest_version() {

--- a/libexec/goenv-version-file-write
+++ b/libexec/goenv-version-file-write
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Summary: Writes specified version(s) to the specified file if the version(s) exist
 # Usage: goenv version-file-write <file> <version>
+# If the specified version is not installed, only display error message and return error code.
+# If only a single version="system" is specified and installed, display previous version (if any) and remove file.
 
 set -e
 [ -n "$GOENV_DEBUG" ] && set -x
@@ -14,12 +16,46 @@ if [ -z "$versions" ] || [ -z "$GOENV_VERSION_FILE" ]; then
   exit 1
 fi
 
-# Make sure the specified version is installed.
-goenv-prefix "${versions[@]}" >/dev/null
+# Make sure the specified version(s) are installed.
+# Use goenv-prefix loop logic.
+if [ -n "$1" ]; then
+  OLDIFS="$IFS"
+  {
+    IFS=:
+    export GOENV_VERSION="$*"
+  }
+  IFS="$OLDIFS"
+elif [ -z "$GOENV_VERSION" ]; then
+  GOENV_VERSION="$(goenv-version-name)"
+fi
 
-# Write the version out to disk.
-# Create an empty file. Using "rm" might cause a permission error.
-> "$GOENV_VERSION_FILE"
-for version in "${versions[@]}"; do
-  echo "$version" >> "$GOENV_VERSION_FILE"
-done
+GOENV_VERSIONS=()
+OLDIFS="$IFS"
+{
+  IFS=:
+  for version in ${GOENV_VERSION}; do
+    if ! INSTALLED="$(goenv-installed "$version" 2>&1)"; then
+      echo "$INSTALLED" >&2
+      exit 1
+    fi
+    GOENV_VERSIONS=("${GOENV_VERSIONS[@]}" "$INSTALLED")
+  done
+}
+IFS="$OLDIFS"
+
+# Special case: only system was specified and found
+if [ "$1" = "system" ]; then
+  if [ -f "$GOENV_VERSION_FILE" ]; then
+    if previous="$(head -1 "$GOENV_VERSION_FILE" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$")"; then
+      echo "goenv: using system version instead of $previous now"
+    fi
+    rm "$GOENV_VERSION_FILE"
+  fi
+else
+  # Write the version out to disk.
+  # Create an empty file. Using "rm" might cause a permission error.
+  > "$GOENV_VERSION_FILE"
+  for version in "${GOENV_VERSIONS[@]}"; do
+    echo "$version" >> "$GOENV_VERSION_FILE"
+  done
+fi

--- a/libexec/goenv-version-file-write
+++ b/libexec/goenv-version-file-write
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 # Summary: Writes specified version(s) to the specified file if the version(s) exist
 # Usage: goenv version-file-write <file> <version>
-# If the specified version is not installed, only display error message and return error code.
-# If only a single version="system" is specified and installed, display previous version (if any) and remove file.
+#
+# If a specified version is not installed, only display an error message and abort.
+# If only a single <version> `system` is specified and installed, display previous version (if any) and remove file (similar to --unset).
+#
+# <version> should be a string matching a Go version known to goenv.
+# <version> `latest` writes the latest installed version (1.23.4).
+# <version> `1` writes the latest installed major version (1.23.4).
+# <version> `23` or `1.23` writes the latest installed minor version (1.23.4).
+# <version> `1.23.4` writes this installed version (1.23.4).
+# Run `goenv versions` for a list of available Go versions.
 
 set -e
 [ -n "$GOENV_DEBUG" ] && set -x

--- a/plugins/go-build/test/goenv-install.bats
+++ b/plugins/go-build/test/goenv-install.bats
@@ -6,18 +6,16 @@ load test_helper
 export PATH="${project_root}/libexec:$PATH"
 
 @test "has usage instructions" {
-  run goenv-help --usage uninstall
-  assert_success
-  assert_output <<'OUT'
-Usage: goenv uninstall [-f|--force] <version>
+  run goenv-help --usage install
+  assert_success <<OUT
+Usage: goenv install [-f|--force] <version>
 OUT
 }
 
 @test "has completion support" {
   export USE_FAKE_DEFINITIONS=true
   run goenv-install --complete
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 --list
 --force
 --skip-existing
@@ -37,8 +35,7 @@ OUT
 
 @test "prints full usage when '-h' is first argument given" {
   run goenv-install -h
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -66,8 +63,7 @@ OUT
 
 @test "prints full usage when '--help' is first argument given" {
   run goenv-install --help
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -95,8 +91,7 @@ OUT
 
 @test "fails and prints full usage when no arguments are given" {
   run goenv-install
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -124,8 +119,7 @@ OUT
 
 @test "fails and prints full usage when '-f' is given and no other arguments" {
   run goenv-install -f
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -153,8 +147,7 @@ OUT
 
 @test "fails and prints full usage when '--force' is given and no other arguments" {
   run goenv-install --force
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -182,8 +175,7 @@ OUT
 
 @test "fails and prints full usage when '-f' is given and '-' version argument" {
   run goenv-install -f -
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -211,8 +203,7 @@ OUT
 
 @test "fails and prints full usage when '--force' is given and '-' version argument" {
   run goenv-install --force
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -247,8 +238,7 @@ SH
 
   IFS=$' \t\n' run goenv-install 1.1.1
   remove_hook install hello.bash
-  assert_success
-  assert_output "HELLO=:hello:ugly:world:again"
+  assert_success "HELLO=:hello:ugly:world:again"
 }
 
 @test "fails when '-f' argument and version argument is not a known version definition" {
@@ -256,8 +246,7 @@ SH
 
   run goenv-install -f 1.2.3
 
-  assert_failure
-  assert_output <<-OUT
+  assert_failure <<OUT
 go-build: definition not found: 1.2.3
 
 See all available versions with 'goenv install --list'.
@@ -273,8 +262,7 @@ OUT
 
   run goenv-install --force 1.2.3
 
-  assert_failure
-  assert_output <<-OUT
+  assert_failure <<OUT
 go-build: definition not found: 1.2.3
 
 See all available versions with 'goenv install --list'.
@@ -289,8 +277,7 @@ OUT
   export USE_FAKE_DEFINITIONS=true
   run goenv-install -l
 
-  assert_success
-  assert_output <<-OUT
+  assert_success <<OUT
 Available versions:
   1.0.0
   1.2.0
@@ -304,8 +291,7 @@ OUT
   export USE_FAKE_DEFINITIONS=true
   run goenv-install --list
 
-  assert_success
-  assert_output <<-OUT
+  assert_success <<OUT
 Available versions:
   1.0.0
   1.2.0
@@ -321,8 +307,7 @@ OUT
 
   run goenv-install --version
 
-  assert_success
-  assert_output <<-OUT
+  assert_success <<OUT
 go-build $(cat $base_dir/APP_VERSION)
 OUT
 }
@@ -349,7 +334,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -359,7 +344,7 @@ Installed Go Linux${arch}64bit ${LATEST_VERSION} to ${GOENV_ROOT}/versions/${LAT
 OUT
     ;;
   Darwin*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -404,7 +389,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -414,7 +399,7 @@ Installed Go Linux${arch}64bit ${LATEST_VERSION} to ${GOENV_ROOT}/versions/${LAT
 OUT
     ;;
   Darwin*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -458,7 +443,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -468,7 +453,7 @@ Installed Go Linux${arch}64bit ${LATEST_VERSION} to ${GOENV_ROOT}/versions/${LAT
 OUT
     ;;
   Darwin*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -509,7 +494,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Installing latest (including unstable) version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -519,7 +504,7 @@ Installed Go Linux${arch}64bit ${LATEST_VERSION} to ${GOENV_ROOT}/versions/${LAT
 OUT
     ;;
   Darwin*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Installing latest (including unstable) version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -557,12 +542,10 @@ OUT
     arch=" arm "
   fi
 
-  assert_output <<-OUT
+  assert_failure <<OUT
 No installable version found for $(uname -s) $(uname -m)
 
 OUT
-
-  assert_failure
 }
 
 @test "{before,after}_install hooks get triggered when '--force' argument and version argument is not already installed version and gets installed" {
@@ -595,7 +578,7 @@ SH
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_output <<-OUT
+    assert_success <<OUT
 before: ${GOENV_ROOT}/versions/1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
@@ -607,7 +590,7 @@ REHASHED
 OUT
     ;;
   Darwin*)
-    assert_output <<-OUT
+    assert_success <<OUT
 before: ${GOENV_ROOT}/versions/1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
@@ -655,7 +638,7 @@ SH
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_output <<-OUT
+    assert_success <<OUT
 before: ${GOENV_ROOT}/versions/1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
@@ -667,7 +650,7 @@ REHASHED
 OUT
     ;;
   Darwin*)
-    assert_output <<-OUT
+    assert_success <<OUT
 before: ${GOENV_ROOT}/versions/1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
@@ -702,7 +685,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
 Installing Go Linux${arch}64bit 1.2.2...
@@ -711,7 +694,7 @@ Installed Go Linux${arch}64bit 1.2.2 to ${GOENV_ROOT}/versions/1.2.2
 OUT
     ;;
   Darwin*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
 Installing Go Darwin 10.8${arch}1.2.2...
@@ -776,7 +759,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Using latest patch version 1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
@@ -786,7 +769,7 @@ Installed Go Linux${arch}64bit 1.2.2 to ${GOENV_ROOT}/versions/1.2.2
 OUT
     ;;
   Darwin*)
-    assert_output <<-OUT
+    assert_success <<OUT
 Using latest patch version 1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz

--- a/plugins/go-build/test/goenv-uninstall.bats
+++ b/plugins/go-build/test/goenv-uninstall.bats
@@ -7,24 +7,21 @@ export PATH="${project_root}/libexec:$PATH"
 
 @test "has usage instructions" {
   run goenv-help --usage uninstall
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 Usage: goenv uninstall [-f|--force] <version>
 OUT
 }
 
 @test "has completion support" {
   run goenv-uninstall --complete
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 --force
 OUT
 }
 
 @test "prints full usage when '-h' is first argument given" {
   run goenv-uninstall -h
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -36,8 +33,7 @@ OUT
 
 @test "prints full usage when '--help' is first argument given" {
   run goenv-uninstall --help
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -49,8 +45,7 @@ OUT
 
 @test "fails and prints full usage when no arguments are given" {
   run goenv-uninstall
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -62,8 +57,7 @@ OUT
 
 @test "fails and prints full usage when '-f' is given and no other arguments" {
   run goenv-uninstall -f
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -75,8 +69,7 @@ OUT
 
 @test "fails and prints full usage when '--force' is given and no other arguments" {
   run goenv-uninstall --force
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -88,8 +81,7 @@ OUT
 
 @test "fails and prints full usage when '-f' is given and '-' version argument" {
   run goenv-uninstall -f -
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -101,8 +93,7 @@ OUT
 
 @test "fails and prints full usage when '--force' is given and '-' version argument" {
   run goenv-uninstall --force
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -121,8 +112,7 @@ SH
 
   IFS=$' \t\n' run goenv-uninstall 1.1.1
   remove_hook uninstall hello.bash
-  assert_success
-  assert_output "HELLO=:hello:ugly:world:again"
+  assert_success "HELLO=:hello:ugly:world:again"
 }
 
 @test "{before,after}_uninstall hooks get triggered when version argument is already installed version and gets uninstalled" {
@@ -141,8 +131,7 @@ SH
   run goenv-uninstall -f 1.2.3
   remove_hook uninstall hello.bash
 
-  assert_success
-  assert_output <<-OUT
+  assert_success <<OUT
 before: ${GOENV_ROOT}/versions/1.2.3
 rm -rf ${GOENV_ROOT}/versions/1.2.3
 after.
@@ -166,8 +155,7 @@ SH
   run goenv-uninstall -f 1.2.3
   remove_hook uninstall hello.bash
 
-  assert_failure
-  assert_output <<-OUT
+  assert_failure <<OUT
 goenv: version '1.2.3' not installed
 OUT
 }
@@ -177,10 +165,7 @@ OUT
 
   run goenv-uninstall -f 1.2.3
 
-  assert_failure
-  assert_output <<-OUT
-goenv: version '1.2.3' not installed
-OUT
+  assert_failure "goenv: version '1.2.3' not installed"
 }
 
 @test "fails when '--force' argument and version argument is not already installed version" {
@@ -188,10 +173,7 @@ OUT
 
   run goenv-uninstall --force 1.2.3
 
-  assert_failure
-  assert_output <<-OUT
-goenv: version '1.2.3' not installed
-OUT
+  assert_failure "goenv: version '1.2.3' not installed"
 }
 
 @test "fails when when version argument is not already installed version" {
@@ -199,10 +181,7 @@ OUT
 
   run goenv-uninstall 1.2.3
 
-  assert_failure
-  assert_output <<-OUT
-goenv: version '1.2.3' not installed
-OUT
+  assert_failure "goenv: version '1.2.3' not installed"
 }
 
 @test "fails when version argument is not already installed version" {
@@ -210,10 +189,7 @@ OUT
 
   run goenv-uninstall 1.2.3
 
-  assert_failure
-  assert_output <<-OUT
-goenv: version '1.2.3' not installed
-OUT
+  assert_failure "goenv: version '1.2.3' not installed"
 }
 
 @test "adds patch version '0' to definition when version argument is already installed version and gets uninstalled" {
@@ -222,10 +198,7 @@ OUT
 
   run goenv-uninstall -f 1.2
 
-  assert_output <<-OUT
-Adding patch version 0 to 1.2
-OUT
-  assert_success
+  assert_success "Adding patch version 0 to 1.2"
 }
 
 @test "shims get rehashed and version uninstalled when version argument is already installed version" {
@@ -240,8 +213,7 @@ OUT
 
   run goenv-uninstall -f 1.10.3
 
-  assert_success
-  assert_output ''
+  assert_success ""
 
   assert [ ! -d "${GOENV_ROOT}/versions/1.2.3" ]
   assert [ ! -e "${GOENV_ROOT}/shims/gofmt" ]

--- a/plugins/go-build/test/installer.bats
+++ b/plugins/go-build/test/installer.bats
@@ -23,7 +23,7 @@ load test_helper
   assert_success ""
 
   run $BASH -c '/bin/ls -l usr/share/go-build | tail -2 | cut -c1-10'
-  assert_output <<OUT
+  assert_success <<OUT
 -rw-r--r--
 -rw-r--r--
 OUT

--- a/test/goenv-commands.bats
+++ b/test/goenv-commands.bats
@@ -2,6 +2,11 @@
 
 load test_helper
 
+setup() {
+  mkdir -p "${GOENV_ROOT}/versions/1.9.2"
+  mkdir -p "${GOENV_ROOT}/versions/1.10.1"
+}
+
 @test "has completion support" {
   run goenv-commands --complete
 
@@ -19,35 +24,42 @@ OUT
 @test "'commands' returns all commands" {
   run goenv-commands
 
-  assert_success
-  assert_line "commands"
-  assert_line "completions"
-  assert_line "exec"
-  assert_line "global"
-  assert_line "help"
-  assert_line "hooks"
-  assert_line "init"
-  assert_line "local"
-  assert_line "prefix"
-  assert_line "rehash"
-  assert_line "root"
-  assert_line "shell"
-  assert_line "shims"
-  assert_line "version"
-  assert_line "--version"
-  assert_line "version-file"
-  assert_line "version-file-read"
-  assert_line "version-file-write"
-  assert_line "version-name"
-  assert_line "version-origin"
-  assert_line "versions"
-  assert_line "whence"
-  assert_line "which"
+  assert_success "1.10.1
+1.9.2
+commands
+completions
+exec
+global
+help
+hooks
+init
+install
+installed
+latest
+local
+prefix
+rehash
+root
+shell
+shims
+system
+uninstall
+version
+version-file
+version-file-read
+version-file-write
+version-name
+version-origin
+versions
+whence
+which"
 }
 
 @test "'commands --sh' returns only commands containing 'sh'" {
   run goenv-commands --sh
-  assert_success
+  assert_success "rehash
+shell"
+
   refute_line "commands"
   refute_line "completions"
   refute_line "exec"
@@ -60,7 +72,6 @@ OUT
   refute_line "root"
   refute_line "shims"
   refute_line "version"
-  refute_line "--version"
   refute_line "version-file"
   refute_line "version-file-read"
   refute_line "version-file-write"
@@ -77,30 +88,34 @@ OUT
 
 @test "'commands --no-sh' returns only commands not containing 'sh'" {
   run goenv-commands --no-sh
-  assert_success
-
-  assert_line "commands"
-  assert_line "completions"
-  assert_line "exec"
-  assert_line "global"
-  assert_line "help"
-  assert_line "hooks"
-  assert_line "init"
-  assert_line "local"
-  assert_line "prefix"
-  assert_line "rehash"
-  assert_line "root"
-  assert_line "shims"
-  assert_line "version"
-  assert_line "--version"
-  assert_line "version-file"
-  assert_line "version-file-read"
-  assert_line "version-file-write"
-  assert_line "version-name"
-  assert_line "version-origin"
-  assert_line "versions"
-  assert_line "whence"
-  assert_line "which"
+  assert_success "1.10.1
+1.9.2
+commands
+completions
+exec
+global
+help
+hooks
+init
+install
+installed
+latest
+local
+prefix
+rehash
+root
+shims
+system
+uninstall
+version
+version-file
+version-file-read
+version-file-write
+version-name
+version-origin
+versions
+whence
+which"
 
   refute_line "shell"
 }

--- a/test/goenv-completions.bats
+++ b/test/goenv-completions.bats
@@ -2,6 +2,11 @@
 
 load test_helper
 
+setup() {
+  mkdir -p "${GOENV_ROOT}/versions/1.9.2"
+  mkdir -p "${GOENV_ROOT}/versions/1.10.1"
+}
+
 create_command() {
   bin="${GOENV_TEST_DIR}/bin"
   mkdir -p "$bin"
@@ -43,8 +48,7 @@ else
   exit 1
 fi"
   run goenv-completions hello
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 --help
 hello
 OUT
@@ -59,8 +63,7 @@ else
   exit 1
 fi"
   run goenv-completions hello
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 --help
 hello
 OUT
@@ -82,8 +85,7 @@ else
   exit 1
 fi"
   run goenv-completions hello happy world
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 --help
 happy
 world

--- a/test/goenv-exec.bats
+++ b/test/goenv-exec.bats
@@ -2,6 +2,11 @@
 
 load test_helper
 
+setup() {
+  mkdir -p "${GOENV_ROOT}/versions/1.9.2"
+  mkdir -p "${GOENV_ROOT}/versions/1.10.1"
+}
+
 @test "has usage instructions" {
   run goenv-help --usage exec
   assert_success "Usage: goenv exec <command> [arg1 arg2...]"
@@ -9,10 +14,7 @@ load test_helper
 
 @test "fails with usage instructions when no command is specified" {
   run goenv-exec
-  assert_failure
-  assert_output <<OUT
-Usage: goenv exec <command> [arg1 arg2...]
-OUT
+  assert_failure "Usage: goenv exec <command> [arg1 arg2...]"
 }
 
 @test "fails with version that's not installed but specified by GOENV_VERSION" {
@@ -36,8 +38,7 @@ OUT
   goenv-rehash
   run goenv-exec Zgo123unique
 
-  assert_output ""
-  assert_success
+  assert_success ""
 }
 
 @test "succeeds with version that's installed and specified by '.go-version' file" {
@@ -56,8 +57,7 @@ OUT
 
   GOENV_VERSION=1.6.1 goenv-rehash
   GOENV_VERSION=1.6.1 run goenv-completions exec
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 --help
 Zgo123unique
 OUT
@@ -85,8 +85,7 @@ done
 SH
 
   GOENV_VERSION=1.6.1 run goenv-exec go run "/path to/go script.go" -- extra args
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 ${GOENV_ROOT}/versions/1.6.1/bin/go
   run
   /path to/go script.go
@@ -106,9 +105,7 @@ echo \$GOPATH
 SH
 
   GOENV_VERSION=system GOENV_SHELL=bash GOROOT="" GOPATH="" PATH="$GOENV_TEST_DIR:$PATH" run goenv-exec go-paths
-
-  assert_output ""
-  assert_success
+  assert_success ""
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 1, shell is 'bash', it does not export GOPATH or GOROOT" {
@@ -120,9 +117,7 @@ echo \$GOPATH
 SH
 
   GOPATH="" GOROOT="" GOENV_SHELL=bash GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=1 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
-
-  assert_output ""
-  assert_success
+  assert_success ""
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 1, shell is 'zsh', it does not export GOPATH or GOROOT" {
@@ -135,8 +130,7 @@ SH
 
   GOPATH="" GOROOT="" GOENV_SHELL=zsh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=1 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output ""
-  assert_success
+  assert_success ""
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 1, shell is 'ksh', it does not export GOPATH or GOROOT" {
@@ -149,8 +143,7 @@ SH
 
   GOPATH="" GOROOT="" GOENV_SHELL=ksh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=1 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output ""
-  assert_success
+  assert_success ""
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 1, shell is 'fish', it does not export GOPATH or GOROOT" {
@@ -163,8 +156,7 @@ SH
 
   GOPATH="" GOROOT="" GOENV_SHELL=fish GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=1 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output ""
-  assert_success
+  assert_success ""
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 0, shell is 'bash', it exports 'GOPATH'" {
@@ -177,11 +169,10 @@ SH
 
   GOROOT="" GOENV_SHELL=bash GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 
 $HOME/go/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 0, shell is 'ksh', it exports 'GOPATH'" {
@@ -194,11 +185,10 @@ SH
 
   GOROOT="" GOENV_SHELL=ksh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 
 $HOME/go/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 0, shell is 'zsh', it exports 'GOPATH'" {
@@ -211,11 +201,10 @@ SH
 
   GOROOT="" GOENV_SHELL=zsh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 
 $HOME/go/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 0, shell is 'fish', it exports 'GOPATH'" {
@@ -228,11 +217,10 @@ SH
 
   GOROOT="" GOENV_SHELL=fish GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 
 $HOME/go/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'bash' and GOENV_GOPATH_PREFIX is empty, it exports 'GOROOT' and 'GOPATH'=\$HOME/go/<version>" {
@@ -245,11 +233,10 @@ SH
 
   GOENV_SHELL=bash GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 $GOENV_ROOT/versions/1.12.0
 $HOME/go/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'zsh' and GOENV_GOPATH_PREFIX is empty, it exports 'GOROOT' and 'GOPATH'=\$HOME/go/<version>" {
@@ -262,11 +249,10 @@ SH
 
   GOENV_SHELL=zsh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 $GOENV_ROOT/versions/1.12.0
 $HOME/go/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'ksh' and GOENV_GOPATH_PREFIX is empty, it exports 'GOROOT' and 'GOPATH'=\$HOME/go/<version>" {
@@ -279,11 +265,10 @@ SH
 
   GOENV_SHELL=ksh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 $GOENV_ROOT/versions/1.12.0
 $HOME/go/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'fish' and GOENV_GOPATH_PREFIX is empty, it exports 'GOROOT' and 'GOPATH'=\$HOME/go/<version>" {
@@ -296,11 +281,10 @@ SH
 
   GOENV_SHELL=fish GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 $GOENV_ROOT/versions/1.12.0
 $HOME/go/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'bash' and GOENV_GOPATH_PREFIX is present, it exports 'GOROOT' and 'GOPATH'=\$HOME/go/<version>" {
@@ -313,11 +297,10 @@ SH
 
   GOENV_SHELL=bash GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="/tmp/goenv/example" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 $GOENV_ROOT/versions/1.12.0
 /tmp/goenv/example/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'ksh' and GOENV_GOPATH_PREFIX is present, it exports 'GOROOT' and 'GOPATH'=\$HOME/go/<version>" {
@@ -330,11 +313,10 @@ SH
 
   GOENV_SHELL=ksh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="/tmp/goenv/example" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 $GOENV_ROOT/versions/1.12.0
 /tmp/goenv/example/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'zsh' and GOENV_GOPATH_PREFIX is present, it exports 'GOROOT' and 'GOPATH'=\$HOME/go/<version>" {
@@ -347,11 +329,10 @@ SH
 
   GOENV_SHELL=zsh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="/tmp/goenv/example" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 $GOENV_ROOT/versions/1.12.0
 /tmp/goenv/example/1.12.0
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'fish' and GOENV_GOPATH_PREFIX is present, it exports 'GOROOT' and 'GOPATH'=\$HOME/go/<version>" {
@@ -364,9 +345,8 @@ SH
 
   GOENV_SHELL=fish GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="/tmp/goenv/example" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_output <<OUT
+  assert_success <<OUT
 $GOENV_ROOT/versions/1.12.0
 /tmp/goenv/example/1.12.0
 OUT
-  assert_success
 }

--- a/test/goenv-global.bats
+++ b/test/goenv-global.bats
@@ -9,47 +9,123 @@ Usage: goenv global <version>
 OUT
 }
 
+@test "global has completion support" {
+  mkdir -p "${GOENV_ROOT}/versions/1.9.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.10.9"
+  run goenv-global --complete
+  assert_success <<OUT
+latest
+system
+1.10.9
+1.9.10
+OUT
+}
+
 @test "defaults to 'system'" {
+  mkdir -p "${GOENV_ROOT}/versions/1.10.1"
   run goenv-global
-  assert_success
-  assert_output "system"
+  assert_success "system"
 }
 
 @test "returns contents of GOENV_ROOT/version" {
+  mkdir -p "${GOENV_ROOT}/versions/1.10.1"
   mkdir -p "$GOENV_ROOT"
   echo "1.2.3" > "$GOENV_ROOT/version"
   run goenv-global
-  assert_success
-  assert_output "1.2.3"
+  assert_success "1.2.3"
 }
 
 @test "returns contents of GOENV_ROOT/global" {
+  mkdir -p "${GOENV_ROOT}/versions/1.10.1"
   mkdir -p "$GOENV_ROOT"
   echo "1.2.3" > "$GOENV_ROOT/global"
   run goenv-global
-  assert_success
-  assert_output "1.2.3"
+  assert_success "1.2.3"
 }
 
 @test "returns contents of GOENV_ROOT/default" {
+  mkdir -p "${GOENV_ROOT}/versions/1.10.1"
   mkdir -p "$GOENV_ROOT"
   echo "1.2.3" > "$GOENV_ROOT/default"
   run goenv-global
-  assert_success
-  assert_output "1.2.3"
+  assert_success "1.2.3"
 }
 
 @test "writes specified version to GOENV_ROOT/version if version is installed" {
   mkdir -p "$GOENV_ROOT/versions/1.2.3"
-  run goenv-global "1.2.3"
+  run goenv-global 1.2.3
   assert_success
   run goenv-global
   assert_success "1.2.3"
 }
 
+@test "sets properly sorted latest global version when 'latest' version is given and any version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.10.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.10.9"
+  mkdir -p "${GOENV_ROOT}/versions/1.9.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.9.9"
+  run goenv-global latest
+  assert_success ""
+  run goenv-global
+  assert_success "1.10.10"
+}
+
+@test "sets latest global version when major version is given and any matching version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/4.5.6"
+  run goenv-global 1
+  assert_success ""
+  run goenv-global
+  assert_success "1.2.10"
+}
+
+@test "fails setting latest global version when major or minor single number is given and does not match at 'GOENV_ROOT/versions/<version>'" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/4.5.10"
+  run goenv-global 9
+  assert_failure "goenv: version '9' not installed"
+}
+
+@test "sets latest global version when minor version is given as single number and any matching major.minor version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/1.3.11"
+  mkdir -p "${GOENV_ROOT}/versions/4.5.2"
+  run goenv-global 2
+  assert_success ""
+  run goenv-global
+  assert_success "1.2.10"
+}
+
+@test "sets latest global version when minor version is given as major.minor number and any matching version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.2"
+  mkdir -p "${GOENV_ROOT}/versions/1.3.11"
+  mkdir -p "${GOENV_ROOT}/versions/2.1.2"
+  run goenv-global 1.2
+  assert_success ""
+  run goenv-global
+  assert_success "1.2.10"
+}
+
+@test "fails setting latest global version when major.minor number is given and does not match at 'GOENV_ROOT/versions/<version>'" {
+  mkdir -p "${GOENV_ROOT}/versions/1.1.9"
+  run goenv-global 1.9
+  assert_failure "goenv: version '1.9' not installed"
+}
+
 @test "fails writing specified version to GOENV_ROOT/version if version is not installed" {
-  run goenv-global "1.2.3"
-  assert_failure
+  mkdir -p "${GOENV_ROOT}/versions/4.5.6"
+  run goenv-global system
+  assert_failure "goenv: system version not found in PATH"
+
+  run goenv-global 1.2.3
+  assert_failure "goenv: version '1.2.3' not installed"
+
+  run goenv-installed 1.2.3
+  assert_failure "goenv: version '1.2.3' not installed"
 
   run goenv-global
   assert_success "system"

--- a/test/goenv-help.bats
+++ b/test/goenv-help.bats
@@ -11,8 +11,7 @@ OUT
 
 @test "without args shows summary of common commands" {
   run goenv-help
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 Usage: goenv <command> [<args>]
 
 Some useful goenv commands are:
@@ -47,8 +46,7 @@ echo hello
 SH
 
   run goenv-help hello
-  assert_success
-  assert_output <<SH
+  assert_success <<SH
 Usage: goenv hello <world>
 
 This command is useful for saying hello.
@@ -65,8 +63,7 @@ echo hello
 SH
 
   run goenv-help hello
-  assert_success
-  assert_output <<SH
+  assert_success <<SH
 Usage: goenv hello <world>
 
 Says "hello" to you, from goenv
@@ -100,8 +97,7 @@ echo hello
 SH
 
   run goenv-help hello
-  assert_success
-  assert_output <<SH
+  assert_success <<SH
 Usage: goenv hello <world>
        goenv hi [everybody]
        goenv hola --translate
@@ -125,8 +121,7 @@ echo hello
 SH
 
   run goenv-help hello
-  assert_success
-  assert_output <<SH
+  assert_success <<SH
 Usage: goenv hello <world>
 
 This is extended help text.

--- a/test/goenv-hooks.bats
+++ b/test/goenv-hooks.bats
@@ -36,8 +36,7 @@ OUT
   create_hook exec "bueno.bash"
 
   GOENV_HOOK_PATH="$path1:$path2" run goenv-hooks exec
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 ${GOENV_TEST_DIR}/goenv.d/exec/ahoy.bash
 ${GOENV_TEST_DIR}/goenv.d/exec/hello.bash
 ${GOENV_TEST_DIR}/etc/goenv_hooks/exec/bueno.bash
@@ -55,8 +54,7 @@ OUT
   create_hook exec "ahoy.bash"
 
   GOENV_HOOK_PATH="$path1:$path2" run goenv-hooks exec
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 ${GOENV_TEST_DIR}/my hooks/goenv.d/exec/hello.bash
 ${GOENV_TEST_DIR}/etc/goenv hooks/exec/ahoy.bash
 OUT

--- a/test/goenv-init.bats
+++ b/test/goenv-init.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage init
-  assert_success <<'OUT'
+  assert_success <<OUT
 eval "$(goenv init - [--no-rehash] [<shell>])"
 OUT
 }
@@ -56,8 +56,7 @@ OUT
 @test "prints usage snippet when no '-' argument is given, but shell given is 'bash'" {
   run goenv-init bash
 
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 # Load goenv automatically by appending
 # the following to ~/.bash_profile:
 
@@ -68,8 +67,7 @@ OUT
 @test "prints usage snippet when no '-' argument is given, but shell given is 'zsh'" {
   run goenv-init zsh
 
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 # Load goenv automatically by appending
 # the following to ~/.zshrc:
 
@@ -80,8 +78,7 @@ OUT
 @test "prints usage snippet when no '-' argument is given, but shell given is 'fish'" {
   run goenv-init fish
 
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 # Load goenv automatically by appending
 # the following to ~/.config/fish/config.fish:
 
@@ -92,8 +89,7 @@ OUT
 @test "prints usage snippet when no '-' argument is given, but shell given is 'ksh'" {
   run goenv-init ksh
 
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 # Load goenv automatically by appending
 # the following to ~/.profile:
 
@@ -104,8 +100,7 @@ OUT
 @test "prints usage snippet when no '-' argument is given, but shell given is none of the well known ones" {
   run goenv-init magicalshell
 
-  assert_success
-  assert_output <<"OUT"
+  assert_success <<OUT
 # Load goenv automatically by appending
 # the following to <unknown shell: magicalshell, replace with your profile path>:
 

--- a/test/goenv-installed.bats
+++ b/test/goenv-installed.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "has usage instructions" {
+  run goenv-help --usage installed
+  assert_success <<OUT
+Usage: goenv installed <version>
+OUT
+}
+
+@test "installed has completion support" {
+  mkdir -p "${GOENV_ROOT}/versions/1.10.9"
+  mkdir -p "${GOENV_ROOT}/versions/1.9.10"
+  run goenv-installed --complete
+  assert_success <<OUT
+latest
+system
+1.10.9
+1.9.10
+OUT
+}
+
+@test "installed fails when no versions are installed" {
+  run goenv-installed
+  assert_failure "goenv: no versions installed"
+}
+
+@test "prints installed version when no arguments are given and there's a '.go-version' file in current dir" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.3"
+  run goenv-installed
+  assert_success "1.2.3"
+}
+
+@test "prints installed version '.go-version' file in parent directory when no arguments are given" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.3"
+  mkdir -p "subdir"
+  cd "subdir"
+
+  run goenv-installed
+  assert_success "1.2.3"
+}
+
+@test "sets installed version when version argument is given and matches at 'GOENV_ROOT/versions/<version>'" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.3"
+  run goenv-installed 1.2.3
+  assert_success "1.2.3"
+}
+
+@test "goenv installed sets properly sorted latest version when 'latest' version is given and any version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.10.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.10.9"
+  mkdir -p "${GOENV_ROOT}/versions/1.9.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.9.9"
+  run goenv-installed latest
+  assert_success "1.10.10"
+}
+
+@test "goenv installed sets latest version when major version is given and any matching version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/4.5.6"
+  run goenv-installed 1
+  assert_success "1.2.10"
+}
+
+@test "goenv installed fails setting latest version when major or minor single number is given and does not match at 'GOENV_ROOT/versions/<version>'" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/4.5.10"
+  run goenv-installed 9
+  assert_failure "goenv: version '9' not installed"
+}
+
+@test "goenv installed sets latest version when minor version is given as single number and any matching major.minor version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/1.3.11"
+  mkdir -p "${GOENV_ROOT}/versions/4.5.2"
+  run goenv-installed 2
+  assert_success "1.2.10"
+}
+
+@test "goenv installed sets latest version when minor version is given as major.minor number and any matching version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.2"
+  mkdir -p "${GOENV_ROOT}/versions/1.3.11"
+  mkdir -p "${GOENV_ROOT}/versions/2.1.2"
+  run goenv-installed 1.2
+  assert_success "1.2.10"
+}
+
+@test "goenv installed fails setting latest version when major.minor number is given and does not match at 'GOENV_ROOT/versions/<version>'" {
+  mkdir -p "${GOENV_ROOT}/versions/1.1.9"
+  run goenv-installed 1.9
+  assert_failure "goenv: version '1.9' not installed"
+}
+
+@test "fails setting installed version when version argument is given and does not match at 'GOENV_ROOT/versions/<version>'" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.3"
+  run goenv-installed 1.2.4
+  assert_failure "goenv: version '1.2.4' not installed"
+}

--- a/test/goenv-prefix.bats
+++ b/test/goenv-prefix.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage prefix
-  assert_success <<'OUT'
+  assert_success <<OUT
 Usage: goenv prefix [<version>]
 OUT
 }
@@ -30,7 +30,7 @@ OUT
   mkdir -p "${GOENV_ROOT}/versions/1.2.3"
 
   run goenv-prefix 1.2
-  assert_output <<-OUT
+  assert_success <<OUT
 Using latest patch version 1.2.3
 ${GOENV_ROOT}/versions/1.2.3
 OUT

--- a/test/goenv-rehash.bats
+++ b/test/goenv-rehash.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage rehash
-  assert_success <<'OUT'
+  assert_success <<OUT
 Usage: goenv rehash
 OUT
 }
@@ -50,8 +50,7 @@ OUT
   assert_success ""
 
   run /bin/ls "${GOENV_ROOT}/shims"
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 go
 godoc
 OUT
@@ -111,7 +110,7 @@ OUT
   chmod +x "${GOENV_ROOT}/shims/oldshim1"
 
   run type oldshim1
-  assert_output "oldshim1 is ${GOENV_ROOT}/shims/oldshim1"
+  assert_success "oldshim1 is ${GOENV_ROOT}/shims/oldshim1"
 
   create_executable "1.11.1" "go"
 
@@ -123,7 +122,7 @@ OUT
 
   assert [ ! -e "${GOENV_ROOT}/shims/oldshim1" ]
   run type go
-  assert_output "go is ${GOENV_ROOT}/shims/go"
+  assert_success "go is ${GOENV_ROOT}/shims/go"
 
   assert [ -x "${GOENV_ROOT}/shims/go" ]
 
@@ -163,13 +162,10 @@ OUT
   assert_success ""
 
   run /bin/ls "${GOENV_ROOT}/shims"
-  assert_success
-  assert_output <<OUT
-go
-OUT
+  assert_success "go"
 
   run type go
-  assert_output "go is ${GOENV_ROOT}/shims/go"
+  assert_success "go is ${GOENV_ROOT}/shims/go"
 }
 
 @test "carries original IFS within hooks" {
@@ -180,6 +176,5 @@ exit
 SH
 
   IFS=$' \t\n' run goenv-rehash
-  assert_success
-  assert_output "HELLO=:hello:ugly:world:again"
+  assert_success "HELLO=:hello:ugly:world:again"
 }

--- a/test/goenv-root.bats
+++ b/test/goenv-root.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage root
-  assert_success <<'OUT'
+  assert_success <<OUT
 Usage: goenv root
 OUT
 }
@@ -12,7 +12,6 @@ OUT
 @test "returns current GOENV_ROOT" {
   GOENV_ROOT=/tmp/whatiexpect run goenv-root
 
-  assert_success
-  assert_output '/tmp/whatiexpect'
+  assert_success '/tmp/whatiexpect'
 }
 

--- a/test/goenv-sh-rehash.bats
+++ b/test/goenv-sh-rehash.bats
@@ -4,23 +4,21 @@ load test_helper
 
 @test "has usage instructions for goenv-sh-rehash" {
   run goenv-help --usage sh-rehash
-  assert_success <<'OUT'
+  assert_success <<OUT
 Usage: goenv sh-rehash
 OUT
 }
 
 @test "has completion support (but pointless)" {
   run goenv-sh-rehash --complete
-  assert_success
-  assert_output ""
+  assert_success ""
 }
 
 @test "when current set 'version' is 'system', it does not export GOPATH and GOROOT env variables" {
   export GOENV_VERSION=system
   export GOENV_SHELL=bash
   run goenv-sh-rehash
-  assert_output ""
-  assert_success
+  assert_success ""
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 1, shell is 'bash', it only echoes rehash of binaries" {
@@ -30,8 +28,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=1 run goenv-sh-rehash
 
-  assert_output "hash -r 2>/dev/null || true"
-  assert_success
+  assert_success "hash -r 2>/dev/null || true"
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 1, shell is 'fish', it does not echo anything" {
@@ -41,8 +38,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=1 run goenv-sh-rehash
 
-  assert_output ""
-  assert_success
+  assert_success ""
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 1, shell is 'ksh', it only echoes rehash of binaries" {
@@ -52,8 +48,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=1 run goenv-sh-rehash
 
-  assert_output "hash -r 2>/dev/null || true"
-  assert_success
+  assert_success "hash -r 2>/dev/null || true"
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 1, shell is 'zsh', it only echoes rehash of binaries" {
@@ -63,8 +58,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=1 run goenv-sh-rehash
 
-  assert_output "hash -r 2>/dev/null || true"
-  assert_success
+  assert_success "hash -r 2>/dev/null || true"
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 0, shell is 'bash', it echoes export of 'GOPATH' and rehash of binaries" {
@@ -74,11 +68,10 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 0, shell is 'ksh', it echoes export of 'GOPATH' and rehash of binaries" {
@@ -88,11 +81,10 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 0, shell is 'zsh', it echoes export of 'GOPATH' and rehash of binaries" {
@@ -102,11 +94,10 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 1, 'GOENV_DISABLE_GOPATH' is 0, shell is 'fish', it echoes only export of 'GOPATH'" {
@@ -116,10 +107,9 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 set -gx GOPATH "${HOME}/go/1.12.0"
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'bash' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go' and rehash of binaries" {
@@ -129,12 +119,11 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_APPEND_GOPATH' is 1, shell is 'bash' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go' and rehash of binaries" {
@@ -144,12 +133,11 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_PREPEND_GOPATH' is 1, shell is 'bash' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go' and rehash of binaries" {
@@ -159,12 +147,11 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'ksh' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go' and rehash of binaries" {
@@ -174,12 +161,11 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_APPEND_GOPATH' is 1, shell is 'ksh' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go' and rehash of binaries" {
@@ -189,12 +175,11 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_PREPEND_GOPATH' is 1, shell is 'ksh' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go' and rehash of binaries" {
@@ -204,12 +189,11 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'zsh' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go' and rehash of binaries" {
@@ -219,12 +203,11 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_APPEND_GOPATH' is 1, shell is 'zsh' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go' and rehash of binaries" {
@@ -234,12 +217,11 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_PREPEND_GOPATH' is 1, shell is 'zsh' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go' and rehash of binaries" {
@@ -249,12 +231,11 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'fish' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go'" {
@@ -264,11 +245,10 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "${HOME}/go/1.12.0"
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_APPEND_GOPATH' is 1, shell is 'fish' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go'" {
@@ -278,11 +258,10 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "${HOME}/go/1.12.0:/fake-gopath"
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_PREPEND_GOPATH' is 1, shell is 'fish' and 'GOENV_GOPATH_PREFIX' is empty, it echoes export of 'GOROOT', 'GOPATH=\$HOME/go'" {
@@ -292,11 +271,10 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "/fake-gopath:${HOME}/go/1.12.0"
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'bash' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT', 'GOPATH=<set>' and rehash of binaries" {
@@ -306,12 +284,11 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_APPEND_GOPATH' is 1, shell is 'bash' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT', 'GOPATH=<set>' and rehash of binaries" {
@@ -321,12 +298,11 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_PREPEND_GOPATH' is 1, shell is 'bash' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT', 'GOPATH=<set>' and rehash of binaries" {
@@ -336,12 +312,11 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'ksh' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT', 'GOPATH=<set>' and rehash of binaries" {
@@ -351,12 +326,11 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_APPEND_GOPATH' is 1, shell is 'ksh' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT', 'GOPATH=<set>' and rehash of binaries" {
@@ -366,12 +340,11 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_PREPEND_GOPATH' is 1, shell is 'ksh' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT', 'GOPATH=<set>' and rehash of binaries" {
@@ -381,12 +354,11 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'zsh' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT', 'GOPATH=<set>' and rehash of binaries" {
@@ -396,12 +368,11 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_APPEND_GOPATH' is 1, shell is 'zsh' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT', 'GOPATH=<set>' and rehash of binaries" {
@@ -411,12 +382,11 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_PREPEND_GOPATH' is 1, shell is 'zsh' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT', 'GOPATH=<set>' and rehash of binaries" {
@@ -426,12 +396,11 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, shell is 'fish' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT' and 'GOPATH=<set>'" {
@@ -441,11 +410,10 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "/tmp/example/1.12.0"
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_APPEND_GOPATH' is 1, shell is 'fish' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT' and 'GOPATH=<set>'" {
@@ -455,11 +423,10 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "/tmp/example/1.12.0:/fake-gopath"
 OUT
-  assert_success
 }
 
 @test "when current set 'version' is not 'system', 'GOENV_DISABLE_GOROOT' is 0, 'GOENV_DISABLE_GOPATH' is 0, 'GOENV_PREPEND_GOPATH' is 1, shell is 'fish' and 'GOENV_GOPATH_PREFIX' is present, it echoes export of 'GOROOT' and 'GOPATH=<set>'" {
@@ -469,11 +436,10 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_output <<OUT
+  assert_success <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "/fake-gopath:/tmp/example/1.12.0"
 OUT
-  assert_success
 }
 
 @test "creates 'GOENV_ROOT/shims' when it does not exist" {
@@ -517,8 +483,7 @@ OUT
   assert_success ""
 
   run /bin/ls "${GOENV_ROOT}/shims"
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 go
 godoc
 OUT
@@ -580,7 +545,7 @@ OUT
   chmod +x "${GOENV_ROOT}/shims/oldshim1"
 
   run type oldshim1
-  assert_output "oldshim1 is ${GOENV_ROOT}/shims/oldshim1"
+  assert_success "oldshim1 is ${GOENV_ROOT}/shims/oldshim1"
 
   create_executable "1.11.1" "go"
 
@@ -592,7 +557,7 @@ OUT
 
   assert [ ! -e "${GOENV_ROOT}/shims/oldshim1" ]
   run type go
-  assert_output "go is ${GOENV_ROOT}/shims/go"
+  assert_success "go is ${GOENV_ROOT}/shims/go"
 
   assert [ -x "${GOENV_ROOT}/shims/go" ]
 
@@ -634,12 +599,11 @@ OUT
   assert_success ""
 
   run /bin/ls "${GOENV_ROOT}/shims"
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 go
 OUT
 
   run type go
-  assert_output "go is ${GOENV_ROOT}/shims/go"
+  assert_success "go is ${GOENV_ROOT}/shims/go"
 }
 

--- a/test/goenv-sh-shell.bats
+++ b/test/goenv-sh-shell.bats
@@ -4,8 +4,7 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage shell
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 Usage: goenv shell <version>
        goenv shell --unset
 OUT
@@ -13,8 +12,7 @@ OUT
 
 @test "has completion support" {
   run goenv-sh-shell --complete
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 --unset
 system
 OUT
@@ -55,8 +53,7 @@ OUT
 
   GOENV_SHELL=bash run goenv-sh-shell 1.2.3
 
-  assert_output 'export GOENV_VERSION="1.2.3"'
-  assert_success
+  assert_success 'export GOENV_VERSION="1.2.3"'
 }
 
 @test "changes 'GOENV_VERSION' environment variable to specified shell version argument if it's installed in GOENV_ROOT/versions/<version> and shell is 'zsh'" {
@@ -64,8 +61,7 @@ OUT
 
   GOENV_SHELL=zsh run goenv-sh-shell 1.2.3
 
-  assert_output 'export GOENV_VERSION="1.2.3"'
-  assert_success
+  assert_success 'export GOENV_VERSION="1.2.3"'
 }
 
 @test "changes 'GOENV_VERSION' environment variable to specified shell version argument if it's installed in GOENV_ROOT/versions/<version> and shell is 'ksh'" {
@@ -73,8 +69,7 @@ OUT
 
   GOENV_SHELL=ksh run goenv-sh-shell 1.2.3
 
-  assert_output 'export GOENV_VERSION="1.2.3"'
-  assert_success
+  assert_success 'export GOENV_VERSION="1.2.3"'
 }
 
 @test "changes 'GOENV_VERSION' environment variable to specified shell version argument if it's installed in GOENV_ROOT/versions/<version> and shell is 'fish'" {
@@ -82,17 +77,14 @@ OUT
 
   GOENV_SHELL=fish run goenv-sh-shell 1.2.3
 
-  assert_output 'set -gx GOENV_VERSION "1.2.3"'
-  assert_success
+  assert_success 'set -gx GOENV_VERSION "1.2.3"'
 }
 
 @test "fails changing 'GOENV_VERSION' environment variable to specified shell version argument if version does not exist in GOENV_ROOT/versions/<version>" {
   GOENV_SHELL=bash run goenv-sh-shell 1.2.3
 
-  assert_output <<OUT
+  assert_failure <<OUT
 goenv: version '1.2.3' not installed
 false
 OUT
-
-  assert_failure
 }

--- a/test/goenv-shims.bats
+++ b/test/goenv-shims.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage shims
-  assert_success <<'OUT'
+  assert_success <<OUT
 Usage: goenv shims [--short]
 OUT
 }
@@ -18,8 +18,7 @@ OUT
 
 @test "prints empty output when no arguments are given and no shims are present in 'GOENV_ROOT/shims/*'" {
   run goenv-shims
-  assert_success
-  assert_output ''
+  assert_success ''
 }
 
 @test "prints found shims paths in alphabetic order when no arguments are given and shims are present in 'GOENV_ROOT/shims/*'" {
@@ -31,13 +30,11 @@ OUT
 
   run goenv-shims
 
-  assert_output <<OUT
+  assert_success <<OUT
 ${GOENV_ROOT}/shims/go
 ${GOENV_ROOT}/shims/godoc
 ${GOENV_ROOT}/shims/gofmt
 OUT
-
-  assert_success
 }
 
 @test "prints found shims names only in alphabetic order when '--short' argument is given and shims are present in 'GOENV_ROOT/shims/*'" {
@@ -49,11 +46,9 @@ OUT
 
   run goenv-shims --short
 
-  assert_output <<OUT
+  assert_success <<OUT
 go
 godoc
 gofmt
 OUT
-
-  assert_success
 }

--- a/test/goenv-version-file-read.bats
+++ b/test/goenv-version-file-read.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version-file-read
-  assert_success <<'OUT'
+  assert_success <<OUT
 Usage: goenv version-file-read <file>
 OUT
 }

--- a/test/goenv-version-file.bats
+++ b/test/goenv-version-file.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version-file
-  assert_success <<'OUT'
+  assert_success <<OUT
 Usage: goenv version-file [<dir>]
 OUT
 }

--- a/test/goenv-version-name.bats
+++ b/test/goenv-version-name.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version-name
-  assert_success <<'OUT'
+  assert_success <<OUT
 Usage: goenv version-name
 OUT
 }
@@ -100,8 +100,7 @@ SH
   # NOTE: Test with last version specified is missing
   GOENV_VERSION="1.11.1:1.10.3" run goenv-version-name
 
-  assert_failure
-  assert_output <<OUT
+  assert_failure <<OUT
 goenv: version '1.10.3' is not installed (set by GOENV_VERSION environment variable)
 1.11.1
 OUT
@@ -109,8 +108,7 @@ OUT
   # NOTE: Test with first version specified is missing
   GOENV_VERSION="1.10.3:1.11.1" run goenv-version-name
 
-  assert_failure
-  assert_output <<OUT
+  assert_failure <<OUT
 goenv: version '1.10.3' is not installed (set by GOENV_VERSION environment variable)
 1.11.1
 OUT
@@ -121,6 +119,5 @@ OUT
   echo "1.10.3" > '.go-version'
   run goenv-version-name
 
-  assert_success
-  assert_output "1.10.3"
+  assert_success "1.10.3"
 }

--- a/test/goenv-version-origin.bats
+++ b/test/goenv-version-origin.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version-origin
-  assert_success <<'OUT'
+  assert_success <<OUT
 Usage: goenv version-origin
 OUT
 }

--- a/test/goenv-version.bats
+++ b/test/goenv-version.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version
-  assert_success <<'OUT'
+  assert_success <<OUT
 Usage: goenv version
 OUT
 }
@@ -51,8 +51,7 @@ OUT
   echo "1.11.1:1.10.3" >"${GOENV_ROOT}/version"
 
   run goenv-version
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 1.11.1 (set by ${GOENV_ROOT}/version)
 1.10.3 (set by ${GOENV_ROOT}/version)
 OUT
@@ -62,8 +61,7 @@ OUT
   create_version "1.11.1"
 
   GOENV_VERSION=1.1:1.11.1:1.2 run goenv-version
-  assert_failure
-  assert_output <<OUT
+  assert_failure <<OUT
 goenv: version '1.1' is not installed (set by GOENV_VERSION environment variable)
 goenv: version '1.2' is not installed (set by GOENV_VERSION environment variable)
 1.11.1 (set by GOENV_VERSION environment variable)
@@ -76,8 +74,7 @@ OUT
   create_version "1.11.1"
 
   GOENV_VERSION=1.1:1.11.1:1.2 run goenv-version
-  assert_failure
-  assert_output <<OUT
+  assert_failure <<OUT
 goenv: version '1.1' is not installed (set by GOENV_VERSION environment variable)
 goenv: version '1.2' is not installed (set by GOENV_VERSION environment variable)
 1.11.1 (set by GOENV_VERSION environment variable)

--- a/test/goenv-versions.bats
+++ b/test/goenv-versions.bats
@@ -15,16 +15,14 @@ stub_system_go() {
 
 @test "has usage instructions" {
   run goenv-help --usage versions
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 Usage: goenv versions [--bare] [--skip-aliases]
 OUT
 }
 
 @test "has completion support" {
   run goenv-versions --complete
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 --bare
 --skip-aliases
 OUT
@@ -32,8 +30,7 @@ OUT
 
 @test "prints usage instructions when unknown arguments are given" {
   run goenv-versions magic and more
-  assert_failure
-  assert_output <<'OUT'
+  assert_failure <<OUT
 Usage: goenv versions [--bare] [--skip-aliases]
 OUT
 }
@@ -49,8 +46,7 @@ OUT
 @test "fails with warning when no versions are installed and no 'go' executable in 'PATH'" {
   PATH="$(path_without go)" run goenv-versions
 
-  assert_failure
-  assert_output "Warning: no Go detected on the system"
+  assert_failure "Warning: no Go detected on the system"
 }
 
 @test "prints empty output when '--bare' argument is given and no versions installed and no 'go' executable in 'PATH'" {
@@ -75,8 +71,7 @@ OUT
   create_version "1.10.1"
   run goenv-versions
 
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 * system (set by ${GOENV_ROOT}/version)
   1.10.1
   1.10.2
@@ -88,8 +83,7 @@ OUT
   create_version "1.10.3"
   run goenv-versions
 
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
   1.10.3
 OUT
 }
@@ -107,8 +101,7 @@ OUT
   create_version "1.11.1"
 
   GOENV_VERSION=1.10.1 run goenv-versions
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
   system
 * 1.10.1 (set by GOENV_VERSION environment variable)
   1.11.1
@@ -119,8 +112,7 @@ OUT
   create_version "1.10.3"
   create_version "1.11.1"
   GOENV_VERSION=1.10.3 run goenv-versions --bare
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 1.10.3
 1.11.1
 OUT
@@ -134,8 +126,7 @@ OUT
   echo "1.11.1" > "${GOENV_ROOT}/version"
   run goenv-versions
 
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
   system
   1.10.3
 * 1.11.1 (set by ${GOENV_ROOT}/version)
@@ -150,8 +141,7 @@ OUT
   echo "1.6.1" > '.go-version'
 
   run goenv-versions
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
   system
 * 1.6.1 (set by ${GOENV_TEST_DIR}/.go-version)
   1.8.4
@@ -173,8 +163,7 @@ OUT
   ln -s "1.8.3" "${GOENV_ROOT}/versions/1.8.4"
 
   run goenv-versions
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
   1.8.3
   1.8.4
 OUT
@@ -185,8 +174,7 @@ OUT
   ln -s "1.8.3" "${GOENV_ROOT}/versions/1.8.4"
 
   run goenv-versions --skip-aliases
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
   1.8.3
 OUT
 }

--- a/test/goenv-whence.bats
+++ b/test/goenv-whence.bats
@@ -4,8 +4,7 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage whence
-  assert_success
-  assert_output <<'OUT'
+  assert_success <<OUT
 Usage: goenv whence [--path] <command>
 OUT
 }
@@ -20,8 +19,7 @@ OUT
 @test "fails and prints usage when no argument is given" {
   run goenv-whence
 
-  assert_failure
-  assert_output <<OUT
+  assert_failure <<OUT
 Usage: goenv whence [--path] <command>
 OUT
 }
@@ -31,8 +29,7 @@ OUT
   create_executable "1.6.1" "go"
 
   run goenv-whence go
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 1.6.0
 1.6.1
 OUT
@@ -43,8 +40,7 @@ OUT
   create_executable "1.6.1" "go"
 
   run goenv-whence --path go
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 ${GOENV_ROOT}/versions/1.6.0/bin/go
 ${GOENV_ROOT}/versions/1.6.1/bin/go
 OUT
@@ -58,8 +54,7 @@ OUT
   create_executable "1.6.1" "go"
 
   run goenv-whence go
-  assert_success
-  assert_output <<OUT
+  assert_success <<OUT
 1.6.1
 OUT
 }
@@ -70,8 +65,6 @@ OUT
   chmod -x "${GOENV_ROOT}/versions/1.6.1/bin/go"
 
   run goenv-whence go
-  assert_failure
-  assert_output <<OUT
-OUT
+  assert_failure ""
 }
 

--- a/test/goenv-which.bats
+++ b/test/goenv-which.bats
@@ -4,23 +4,17 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage which
-  assert_success <<'OUT'
-Usage: goenv which <command>
-OUT
+  assert_success "Usage: goenv which <command>"
 }
 
 @test "has completion support" {
   run goenv-which --complete
-  assert_success <<OUT
-OUT
+  assert_success ""
 }
 
 @test "fails and prints usage when no command argument is given" {
   run goenv-which
-  assert_failure
-  assert_output <<OUT
-Usage: goenv which <command>
-OUT
+  assert_failure "Usage: goenv which <command>"
 }
 
 @test "prints path to executable when 'GOENV_VERSION' environment variable is specified and executable argument is found in 'GOENV_ROOT/versions/<version>/bin/<executable>'" {
@@ -28,12 +22,10 @@ OUT
   create_executable "1.11.1" "go"
 
   GOENV_VERSION=1.10.3 run goenv-which gofmt
-  assert_success
-  assert_output "${GOENV_ROOT}/versions/1.10.3/bin/gofmt"
+  assert_success "${GOENV_ROOT}/versions/1.10.3/bin/gofmt"
 
   GOENV_VERSION=1.11.1 run goenv-which go
-  assert_success
-  assert_output "${GOENV_ROOT}/versions/1.11.1/bin/go"
+  assert_success "${GOENV_ROOT}/versions/1.11.1/bin/go"
 }
 
 @test "prints path to executable of first version specified when multiple versions separated by ':' from 'GOENV_VERSION' environment variable executable argument is found in 'GOENV_ROOT/versions/<version>/bin/<executable>'" {
@@ -41,12 +33,10 @@ OUT
   create_executable "1.11.1" "gofmt"
 
   GOENV_VERSION=1.11.1:1.10.3 run goenv-which gofmt
-  assert_success
-  assert_output "${GOENV_ROOT}/versions/1.11.1/bin/gofmt"
+  assert_success "${GOENV_ROOT}/versions/1.11.1/bin/gofmt"
 
   GOENV_VERSION=1.10.3:1.11.1 run goenv-which gofmt
-  assert_success
-  assert_output "${GOENV_ROOT}/versions/1.10.3/bin/gofmt"
+  assert_success "${GOENV_ROOT}/versions/1.10.3/bin/gofmt"
 }
 
 @test "fails when specified version by 'GOENV_VERSION' environment variable is not installed" {
@@ -56,8 +46,7 @@ OUT
 
 @test "fails when specified versions separated by ':' from 'GOENV_VERSION' environment variable are not installed" {
   GOENV_VERSION=1.10.3:1.11.1 run goenv-which go
-  assert_failure
-  assert_output <<OUT
+  assert_failure <<OUT
 goenv: version '1.10.3' is not installed (set by GOENV_VERSION environment variable)
 goenv: version '1.11.1' is not installed (set by GOENV_VERSION environment variable)
 OUT
@@ -81,8 +70,7 @@ OUT
   create_executable "1.11.1" "gofmt"
 
   GOENV_VERSION=1.4.0 run -127 goenv-which gofmt
-  assert_failure
-  assert_output <<OUT
+  assert_failure <<OUT
 goenv: 'gofmt' command not found
 
 The 'gofmt' command exists in these Go versions:
@@ -99,8 +87,7 @@ exit
 SH
 
   IFS=$' \t\n' GOENV_VERSION=system run goenv-which anything
-  assert_success
-  assert_output "HELLO=:hello:ugly:world:again"
+  assert_success "HELLO=:hello:ugly:world:again"
 }
 
 @test "prints executable found in version discovered from 'goenv-version-name' (GOENV_ROOT/version)" {

--- a/test/goenv_ext.bats
+++ b/test/goenv_ext.bats
@@ -21,7 +21,7 @@ load test_helper
   touch "${GOENV_TEST_DIR}/dir1/file.go"
 
   GOENV_FILE_ARG="${GOENV_TEST_DIR}/dir1/file.go" run goenv echo GOENV_DIR
-  assert_output "${GOENV_TEST_DIR}/dir1"
+  assert_success "${GOENV_TEST_DIR}/dir1"
 }
 
 @test "follows symlink of file argument as 'GOENV_DIR' environment variable" {
@@ -31,5 +31,5 @@ load test_helper
   ln -s "${GOENV_TEST_DIR}/dir1/file.go" "${GOENV_TEST_DIR}/dir2/symlink.go"
 
   GOENV_FILE_ARG="${GOENV_TEST_DIR}/dir2/symlink.go" run goenv echo GOENV_DIR
-  assert_output "${GOENV_TEST_DIR}/dir1"
+  assert_success "${GOENV_TEST_DIR}/dir1"
 }


### PR DESCRIPTION
### Features
* `goenv local system` -> if system is installed, removes existing .go-env.version if it exists printing the previous version
> goenv: using system version instead of 1.22.3 now

* `goenv local latest` -> 1.22.3 (latest installed version)
* `goenv local 1` -> 1.22.3 (latest installed major version)
* `goenv local 22` -> 1.22.3 (latest installed minor version when combined with a major version)
* `goenv local 1.22` -> 1.22.3 (latest installed minor version)
* `goenv 1` assumes `goenv local 1` if any of those single version identifiers are given
* That means new "virtual" commands `goenv latest` and `goenv system`
* `goenv global` supports the same version identifiers like `local` (both use goenv-version-file-write)
* Extracted new `goenv installed` command (leaving `prefix` unchanged for now)
* Offer all installed versions plus `latest` and `system` as completions
* Boost grep performance
* Allow Dependabot to update GitHub actions

### Fixes
* Sort versions correctly (1.20.9 comes before 1.20.10), only in `prefix` and `local` for now (not inside `versions` yet)
* `commands` (and therefore `completions`) include plugins `un-/install` now (and all installed versions plus `latest` and `system`)
* Some test cases

### TODO
* Rewrite `prefix` to use `installed` (logic needs to be changed)