### PR TITLE
chore: Display better code statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# GitHub "Languages" statistics only consider file extensions, not contents
+# https://github.com/github-linguist/linguist/blob/master/docs/overrides.md
+# Reclassify files as Shell for proper statistics (instead of "Roff")
+libexec/* linguist-language=Shell
+plugins/go-build/bin/* linguist-language=Shell
+plugins/go-build/share/go-build/* linguist-language=Shell
+plugins/go-build/test/fixtures/definitions/* linguist-language=Shell
+plugins/go-build/test/stubs/* linguist-language=Shell
+src/shobj-conf/* linguist-language=Shell
+test/libexec/* linguist-language=Shell
+


### PR DESCRIPTION
GitHub "Languages" statistics only consider file extensions, not contents.
Now they are not correct:
<img width="311" alt="Languages statistics goenv" src="https://github.com/go-nv/goenv/assets/65483435/8742c1e5-60e8-4dd0-8fef-d202f65a8b79">


### Features
* Improve `Languages` statistics by reclassifying files without extension