### PR TITLE
feat: prefix allows all version identifiers

### DIFF
--- a/libexec/goenv-prefix
+++ b/libexec/goenv-prefix
@@ -2,15 +2,22 @@
 # Summary: Display prefix for a Go version
 # Usage: goenv prefix [<version>]
 #
-# Displays the directory where a Go version is installed. If no
-# version is given, `goenv prefix' displays the location of the
-# currently selected version.
+# Displays the directory where a Go version is installed.
+# If no <version> is given, displays the location of the currently selected version.
+# <version> `latest` is given, displays the latest installed version (1.23.4).
+# <version> `system` displays the system Go location if installed.
+# <version> `1` displays the latest installed major version (1.23.4).
+# <version> `23` or `1.23` displays the latest installed minor version (1.23.4).
+# <version> `1.23.4` displays this installed version (1.23.4).
+# If no version can be found or no versions are installed, an error message will be displayed.
+# Run `goenv versions` for a list of available Go versions.
 
 set -e
 [ -n "$GOENV_DEBUG" ] && set -x
 
 # Provide goenv completions
 if [ "$1" = "--complete" ]; then
+  echo latest
   echo system
   exec goenv-versions --bare
 fi
@@ -48,21 +55,13 @@ OLDIFS="$IFS"
         exit 1
       fi
     else
-      if grep -q -E "^[0-9]+\.[0-9]+(\s*)$" <<<${version}; then
-        REGEX=$(echo $version | sed s/\\./\\\\./)
-        LATEST_PATCH=$(latest_version $REGEX)
-        echo "Using latest patch version $LATEST_PATCH"
-        version=$LATEST_PATCH
+      if ! LATEST_PATCH="$(goenv-installed "$version" 2>&1)"; then
+        echo "goenv: version '${version}' not installed" >&2
+        exit 1
       fi
-
-      GOENV_PREFIX_PATH="${GOENV_ROOT}/versions/${version}"
+      GOENV_PREFIX_PATH="${GOENV_ROOT}/versions/$LATEST_PATCH"
     fi
-    if [ -d "$GOENV_PREFIX_PATH" ]; then
-      GOENV_PREFIX_PATHS=("${GOENV_PREFIX_PATHS[@]}" "$GOENV_PREFIX_PATH")
-    else
-      echo "goenv: version '${version}' not installed" >&2
-      exit 1
-    fi
+    GOENV_PREFIX_PATHS=("${GOENV_PREFIX_PATHS[@]}" "$GOENV_PREFIX_PATH")
   done
 }
 IFS="$OLDIFS"

--- a/libexec/goenv-version-file-write
+++ b/libexec/goenv-version-file-write
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Summary: Writes specified version(s) to the specified file if the version(s) exist
-# Usage: goenv version-file-write <file> <version>
+# Usage: goenv version-file-write <file> <version>...
 #
 # If a specified version is not installed, only display an error message and abort.
 # If only a single <version> `system` is specified and installed, display previous version (if any) and remove file (similar to --unset).

--- a/libexec/goenv-version-origin
+++ b/libexec/goenv-version-origin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Summary: Explain how the current Go version is set
-# Usage: goenv-version-origin
+# Usage: goenv version-origin
 
 set -e
 [ -n "$GOENV_DEBUG" ] && set -x

--- a/plugins/go-build/test/goenv-install.bats
+++ b/plugins/go-build/test/goenv-install.bats
@@ -7,15 +7,18 @@ export PATH="${project_root}/libexec:$PATH"
 
 @test "has usage instructions" {
   run goenv-help --usage install
-  assert_success <<OUT
-Usage: goenv install [-f|--force] <version>
+  assert_success_out <<OUT
+Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
+       goenv install [-f] [-kvpq] <definition-file>
+       goenv install -l|--list
+       goenv install --version
 OUT
 }
 
 @test "has completion support" {
   export USE_FAKE_DEFINITIONS=true
   run goenv-install --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 --list
 --force
 --skip-existing
@@ -35,7 +38,7 @@ OUT
 
 @test "prints full usage when '-h' is first argument given" {
   run goenv-install -h
-  assert_success <<OUT
+  assert_success_out <<'OUT'
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -63,7 +66,7 @@ OUT
 
 @test "prints full usage when '--help' is first argument given" {
   run goenv-install --help
-  assert_success <<OUT
+  assert_success_out <<'OUT'
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -91,7 +94,7 @@ OUT
 
 @test "fails and prints full usage when no arguments are given" {
   run goenv-install
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -119,7 +122,7 @@ OUT
 
 @test "fails and prints full usage when '-f' is given and no other arguments" {
   run goenv-install -f
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -147,7 +150,7 @@ OUT
 
 @test "fails and prints full usage when '--force' is given and no other arguments" {
   run goenv-install --force
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -175,7 +178,7 @@ OUT
 
 @test "fails and prints full usage when '-f' is given and '-' version argument" {
   run goenv-install -f -
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -203,7 +206,7 @@ OUT
 
 @test "fails and prints full usage when '--force' is given and '-' version argument" {
   run goenv-install --force
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -246,7 +249,7 @@ SH
 
   run goenv-install -f 1.2.3
 
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 go-build: definition not found: 1.2.3
 
 See all available versions with 'goenv install --list'.
@@ -262,7 +265,7 @@ OUT
 
   run goenv-install --force 1.2.3
 
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 go-build: definition not found: 1.2.3
 
 See all available versions with 'goenv install --list'.
@@ -277,7 +280,7 @@ OUT
   export USE_FAKE_DEFINITIONS=true
   run goenv-install -l
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 Available versions:
   1.0.0
   1.2.0
@@ -291,7 +294,7 @@ OUT
   export USE_FAKE_DEFINITIONS=true
   run goenv-install --list
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 Available versions:
   1.0.0
   1.2.0
@@ -307,7 +310,7 @@ OUT
 
   run goenv-install --version
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 go-build $(cat $base_dir/APP_VERSION)
 OUT
 }
@@ -334,7 +337,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -344,7 +347,7 @@ Installed Go Linux${arch}64bit ${LATEST_VERSION} to ${GOENV_ROOT}/versions/${LAT
 OUT
     ;;
   Darwin*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -389,7 +392,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -399,7 +402,7 @@ Installed Go Linux${arch}64bit ${LATEST_VERSION} to ${GOENV_ROOT}/versions/${LAT
 OUT
     ;;
   Darwin*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -443,7 +446,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -453,7 +456,7 @@ Installed Go Linux${arch}64bit ${LATEST_VERSION} to ${GOENV_ROOT}/versions/${LAT
 OUT
     ;;
   Darwin*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Installing latest version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -494,7 +497,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Installing latest (including unstable) version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -504,7 +507,7 @@ Installed Go Linux${arch}64bit ${LATEST_VERSION} to ${GOENV_ROOT}/versions/${LAT
 OUT
     ;;
   Darwin*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Installing latest (including unstable) version ${LATEST_VERSION}...
 Downloading ${LATEST_VERSION}.tar.gz...
 -> http://localhost:8090/${LATEST_VERSION}/${LATEST_VERSION}.tar.gz
@@ -542,7 +545,7 @@ OUT
     arch=" arm "
   fi
 
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 No installable version found for $(uname -s) $(uname -m)
 
 OUT
@@ -578,7 +581,7 @@ SH
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 before: ${GOENV_ROOT}/versions/1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
@@ -590,7 +593,7 @@ REHASHED
 OUT
     ;;
   Darwin*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 before: ${GOENV_ROOT}/versions/1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
@@ -638,7 +641,7 @@ SH
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 before: ${GOENV_ROOT}/versions/1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
@@ -650,7 +653,7 @@ REHASHED
 OUT
     ;;
   Darwin*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 before: ${GOENV_ROOT}/versions/1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
@@ -685,7 +688,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
 Installing Go Linux${arch}64bit 1.2.2...
@@ -694,7 +697,7 @@ Installed Go Linux${arch}64bit 1.2.2 to ${GOENV_ROOT}/versions/1.2.2
 OUT
     ;;
   Darwin*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
 Installing Go Darwin 10.8${arch}1.2.2...
@@ -759,7 +762,7 @@ OUT
   unameOut="$(uname -s)"
   case "${unameOut}" in
   Linux*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Using latest patch version 1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
@@ -769,7 +772,7 @@ Installed Go Linux${arch}64bit 1.2.2 to ${GOENV_ROOT}/versions/1.2.2
 OUT
     ;;
   Darwin*)
-    assert_success <<OUT
+    assert_success_out <<OUT
 Using latest patch version 1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz

--- a/plugins/go-build/test/goenv-uninstall.bats
+++ b/plugins/go-build/test/goenv-uninstall.bats
@@ -7,21 +7,21 @@ export PATH="${project_root}/libexec:$PATH"
 
 @test "has usage instructions" {
   run goenv-help --usage uninstall
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv uninstall [-f|--force] <version>
 OUT
 }
 
 @test "has completion support" {
   run goenv-uninstall --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 --force
 OUT
 }
 
 @test "prints full usage when '-h' is first argument given" {
   run goenv-uninstall -h
-  assert_success <<OUT
+  assert_success_out <<'OUT'
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -33,7 +33,7 @@ OUT
 
 @test "prints full usage when '--help' is first argument given" {
   run goenv-uninstall --help
-  assert_success <<OUT
+  assert_success_out <<'OUT'
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -45,7 +45,7 @@ OUT
 
 @test "fails and prints full usage when no arguments are given" {
   run goenv-uninstall
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -57,7 +57,7 @@ OUT
 
 @test "fails and prints full usage when '-f' is given and no other arguments" {
   run goenv-uninstall -f
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -69,7 +69,7 @@ OUT
 
 @test "fails and prints full usage when '--force' is given and no other arguments" {
   run goenv-uninstall --force
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -81,7 +81,7 @@ OUT
 
 @test "fails and prints full usage when '-f' is given and '-' version argument" {
   run goenv-uninstall -f -
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -93,7 +93,7 @@ OUT
 
 @test "fails and prints full usage when '--force' is given and '-' version argument" {
   run goenv-uninstall --force
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv uninstall [-f|--force] <version>
 
    -f  Attempt to remove the specified version without prompting
@@ -131,7 +131,7 @@ SH
   run goenv-uninstall -f 1.2.3
   remove_hook uninstall hello.bash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 before: ${GOENV_ROOT}/versions/1.2.3
 rm -rf ${GOENV_ROOT}/versions/1.2.3
 after.
@@ -155,7 +155,7 @@ SH
   run goenv-uninstall -f 1.2.3
   remove_hook uninstall hello.bash
 
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 goenv: version '1.2.3' not installed
 OUT
 }

--- a/plugins/go-build/test/installer.bats
+++ b/plugins/go-build/test/installer.bats
@@ -23,7 +23,7 @@ load test_helper
   assert_success ""
 
   run $BASH -c '/bin/ls -l usr/share/go-build | tail -2 | cut -c1-10'
-  assert_success <<OUT
+  assert_success_out <<OUT
 -rw-r--r--
 -rw-r--r--
 OUT

--- a/test/goenv-commands.bats
+++ b/test/goenv-commands.bats
@@ -10,7 +10,7 @@ setup() {
 @test "has completion support" {
   run goenv-commands --complete
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 --sh
 --no-sh
 OUT

--- a/test/goenv-completions.bats
+++ b/test/goenv-completions.bats
@@ -35,8 +35,10 @@ else
   exit 1
 fi"
   run goenv-completions hello
-  assert_success
-  assert_line '--help'
+  assert_success_out <<OUT
+--help
+not_important
+OUT
 }
 
 @test "it returns specified command with completion support's completion suggestions" {
@@ -48,7 +50,7 @@ else
   exit 1
 fi"
   run goenv-completions hello
-  assert_success <<OUT
+  assert_success_out <<OUT
 --help
 hello
 OUT
@@ -63,7 +65,7 @@ else
   exit 1
 fi"
   run goenv-completions hello
-  assert_success <<OUT
+  assert_success_out <<OUT
 --help
 hello
 OUT
@@ -85,7 +87,7 @@ else
   exit 1
 fi"
   run goenv-completions hello happy world
-  assert_success <<OUT
+  assert_success_out <<OUT
 --help
 happy
 world

--- a/test/goenv-exec.bats
+++ b/test/goenv-exec.bats
@@ -49,7 +49,7 @@ setup() {
 
   goenv-rehash
   run goenv-exec Zgo123unique
-  assert_success
+  assert_success ""
 }
 
 @test "completes with names of executables for version that's specified by GOENV_VERSION environment variable" {
@@ -57,7 +57,7 @@ setup() {
 
   GOENV_VERSION=1.6.1 goenv-rehash
   GOENV_VERSION=1.6.1 run goenv-completions exec
-  assert_success <<OUT
+  assert_success_out <<OUT
 --help
 Zgo123unique
 OUT
@@ -85,7 +85,7 @@ done
 SH
 
   GOENV_VERSION=1.6.1 run goenv-exec go run "/path to/go script.go" -- extra args
-  assert_success <<OUT
+  assert_success_out <<OUT
 ${GOENV_ROOT}/versions/1.6.1/bin/go
   run
   /path to/go script.go
@@ -169,7 +169,7 @@ SH
 
   GOROOT="" GOENV_SHELL=bash GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 
 $HOME/go/1.12.0
 OUT
@@ -185,7 +185,7 @@ SH
 
   GOROOT="" GOENV_SHELL=ksh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 
 $HOME/go/1.12.0
 OUT
@@ -201,7 +201,7 @@ SH
 
   GOROOT="" GOENV_SHELL=zsh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 
 $HOME/go/1.12.0
 OUT
@@ -217,7 +217,7 @@ SH
 
   GOROOT="" GOENV_SHELL=fish GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 
 $HOME/go/1.12.0
 OUT
@@ -233,7 +233,7 @@ SH
 
   GOENV_SHELL=bash GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 $GOENV_ROOT/versions/1.12.0
 $HOME/go/1.12.0
 OUT
@@ -249,7 +249,7 @@ SH
 
   GOENV_SHELL=zsh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 $GOENV_ROOT/versions/1.12.0
 $HOME/go/1.12.0
 OUT
@@ -265,7 +265,7 @@ SH
 
   GOENV_SHELL=ksh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 $GOENV_ROOT/versions/1.12.0
 $HOME/go/1.12.0
 OUT
@@ -281,7 +281,7 @@ SH
 
   GOENV_SHELL=fish GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 $GOENV_ROOT/versions/1.12.0
 $HOME/go/1.12.0
 OUT
@@ -297,7 +297,7 @@ SH
 
   GOENV_SHELL=bash GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="/tmp/goenv/example" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 $GOENV_ROOT/versions/1.12.0
 /tmp/goenv/example/1.12.0
 OUT
@@ -313,7 +313,7 @@ SH
 
   GOENV_SHELL=ksh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="/tmp/goenv/example" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 $GOENV_ROOT/versions/1.12.0
 /tmp/goenv/example/1.12.0
 OUT
@@ -329,7 +329,7 @@ SH
 
   GOENV_SHELL=zsh GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="/tmp/goenv/example" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 $GOENV_ROOT/versions/1.12.0
 /tmp/goenv/example/1.12.0
 OUT
@@ -345,7 +345,7 @@ SH
 
   GOENV_SHELL=fish GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_GOPATH_PREFIX="/tmp/goenv/example" PATH=${GOENV_TEST_DIR}:${PATH} run goenv-exec go-paths
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 $GOENV_ROOT/versions/1.12.0
 /tmp/goenv/example/1.12.0
 OUT

--- a/test/goenv-global.bats
+++ b/test/goenv-global.bats
@@ -3,9 +3,9 @@
 load test_helper
 
 @test "has usage instructions" {
-  run goenv-help global
-  assert_success <<OUT
-Usage: goenv global <version>
+  run goenv-help --usage global
+  assert_success_out <<OUT
+Usage: goenv global [<version>]
 OUT
 }
 
@@ -13,7 +13,7 @@ OUT
   mkdir -p "${GOENV_ROOT}/versions/1.9.10"
   mkdir -p "${GOENV_ROOT}/versions/1.10.9"
   run goenv-global --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 latest
 system
 1.10.9
@@ -54,7 +54,7 @@ OUT
 @test "writes specified version to GOENV_ROOT/version if version is installed" {
   mkdir -p "$GOENV_ROOT/versions/1.2.3"
   run goenv-global 1.2.3
-  assert_success
+  assert_success ""
   run goenv-global
   assert_success "1.2.3"
 }

--- a/test/goenv-help.bats
+++ b/test/goenv-help.bats
@@ -3,15 +3,15 @@
 load test_helper
 
 @test "has usage instructions" {
-  run goenv-help help
-  assert_success <<OUT
-goenv help [--usage] COMMAND
+  run goenv-help --usage help
+  assert_success_out <<OUT
+Usage: goenv help [--usage] COMMAND
 OUT
 }
 
 @test "without args shows summary of common commands" {
   run goenv-help
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv <command> [<args>]
 
 Some useful goenv commands are:
@@ -46,7 +46,7 @@ echo hello
 SH
 
   run goenv-help hello
-  assert_success <<SH
+  assert_success_out <<SH
 Usage: goenv hello <world>
 
 This command is useful for saying hello.
@@ -63,7 +63,7 @@ echo hello
 SH
 
   run goenv-help hello
-  assert_success <<SH
+  assert_success_out <<SH
 Usage: goenv hello <world>
 
 Says "hello" to you, from goenv
@@ -97,7 +97,7 @@ echo hello
 SH
 
   run goenv-help hello
-  assert_success <<SH
+  assert_success_out <<SH
 Usage: goenv hello <world>
        goenv hi [everybody]
        goenv hola --translate
@@ -121,7 +121,7 @@ echo hello
 SH
 
   run goenv-help hello
-  assert_success <<SH
+  assert_success_out <<SH
 Usage: goenv hello <world>
 
 This is extended help text.

--- a/test/goenv-hooks.bats
+++ b/test/goenv-hooks.bats
@@ -5,7 +5,7 @@ load test_helper
 @test "has completion support" {
   run goenv-hooks --complete
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 exec
 rehash
 version-name
@@ -36,7 +36,7 @@ OUT
   create_hook exec "bueno.bash"
 
   GOENV_HOOK_PATH="$path1:$path2" run goenv-hooks exec
-  assert_success <<OUT
+  assert_success_out <<OUT
 ${GOENV_TEST_DIR}/goenv.d/exec/ahoy.bash
 ${GOENV_TEST_DIR}/goenv.d/exec/hello.bash
 ${GOENV_TEST_DIR}/etc/goenv_hooks/exec/bueno.bash
@@ -54,7 +54,7 @@ OUT
   create_hook exec "ahoy.bash"
 
   GOENV_HOOK_PATH="$path1:$path2" run goenv-hooks exec
-  assert_success <<OUT
+  assert_success_out <<OUT
 ${GOENV_TEST_DIR}/my hooks/goenv.d/exec/hello.bash
 ${GOENV_TEST_DIR}/etc/goenv hooks/exec/ahoy.bash
 OUT
@@ -81,7 +81,7 @@ OUT
   ln -s "bright.sh" "${path}/exec/world.bash"
 
   GOENV_HOOK_PATH="$path" run goenv-hooks exec
-  assert_success <<OUT
+  assert_success_out <<OUT
 ${HOME}/hola.bash
 ${GOENV_TEST_DIR}/goenv.d/exec/bright.sh
 OUT

--- a/test/goenv-init.bats
+++ b/test/goenv-init.bats
@@ -4,14 +4,14 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage init
-  assert_success <<OUT
-eval "$(goenv init - [--no-rehash] [<shell>])"
+  assert_success_out <<'OUT'
+Usage: eval "$(goenv init - [--no-rehash] [<shell>])"
 OUT
 }
 
 @test "has completion support" {
   run goenv-init --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 -
 --no-rehash
 bash
@@ -56,7 +56,7 @@ OUT
 @test "prints usage snippet when no '-' argument is given, but shell given is 'bash'" {
   run goenv-init bash
 
-  assert_success <<OUT
+  assert_success_out <<'OUT'
 # Load goenv automatically by appending
 # the following to ~/.bash_profile:
 
@@ -67,7 +67,7 @@ OUT
 @test "prints usage snippet when no '-' argument is given, but shell given is 'zsh'" {
   run goenv-init zsh
 
-  assert_success <<OUT
+  assert_success_out <<'OUT'
 # Load goenv automatically by appending
 # the following to ~/.zshrc:
 
@@ -78,7 +78,7 @@ OUT
 @test "prints usage snippet when no '-' argument is given, but shell given is 'fish'" {
   run goenv-init fish
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 # Load goenv automatically by appending
 # the following to ~/.config/fish/config.fish:
 
@@ -89,7 +89,7 @@ OUT
 @test "prints usage snippet when no '-' argument is given, but shell given is 'ksh'" {
   run goenv-init ksh
 
-  assert_success <<OUT
+  assert_success_out <<'OUT'
 # Load goenv automatically by appending
 # the following to ~/.profile:
 
@@ -100,7 +100,7 @@ OUT
 @test "prints usage snippet when no '-' argument is given, but shell given is none of the well known ones" {
   run goenv-init magicalshell
 
-  assert_success <<OUT
+  assert_success_out <<'OUT'
 # Load goenv automatically by appending
 # the following to <unknown shell: magicalshell, replace with your profile path>:
 

--- a/test/goenv-installed.bats
+++ b/test/goenv-installed.bats
@@ -4,8 +4,8 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage installed
-  assert_success <<OUT
-Usage: goenv installed <version>
+  assert_success_out <<OUT
+Usage: goenv installed [<version>]
 OUT
 }
 
@@ -13,7 +13,7 @@ OUT
   mkdir -p "${GOENV_ROOT}/versions/1.10.9"
   mkdir -p "${GOENV_ROOT}/versions/1.9.10"
   run goenv-installed --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 latest
 system
 1.10.9

--- a/test/goenv-local.bats
+++ b/test/goenv-local.bats
@@ -9,8 +9,8 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage local
-  assert_success <<OUT
-Usage: goenv local <version>
+  assert_success_out <<OUT
+Usage: goenv local [<version>]
        goenv local --unset
 OUT
 }
@@ -19,7 +19,7 @@ OUT
   mkdir -p "${GOENV_ROOT}/versions/1.9.10"
   mkdir -p "${GOENV_ROOT}/versions/1.10.9"
   run goenv-installed --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 latest
 system
 1.10.9

--- a/test/goenv-prefix.bats
+++ b/test/goenv-prefix.bats
@@ -4,15 +4,20 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage prefix
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv prefix [<version>]
 OUT
 }
 
 @test "has completion support" {
-  run goenv-local --complete
-  assert_success <<OUT
---unset
+  mkdir -p "${GOENV_ROOT}/versions/1.9.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.10.9"
+  run goenv-prefix --complete
+  assert_success_out <<OUT
+latest
+system
+1.10.9
+1.9.10
 OUT
 }
 
@@ -30,8 +35,7 @@ OUT
   mkdir -p "${GOENV_ROOT}/versions/1.2.3"
 
   run goenv-prefix 1.2
-  assert_success <<OUT
-Using latest patch version 1.2.3
+  assert_success_out <<OUT
 ${GOENV_ROOT}/versions/1.2.3
 OUT
 }
@@ -41,12 +45,21 @@ OUT
   assert_failure "goenv: system version not found in PATH"
 }
 
-@test "returns dir containing 'go' when no '.go-version' exists, version is system and there's 'go' executable in PATH" {
+@test "returns dir containing 'go' when no '.go-version' exists, GOENV_VERSION is system and there's 'go' executable in PATH" {
   mkdir -p "${GOENV_TEST_DIR}/bin"
   touch "${GOENV_TEST_DIR}/bin/go"
   chmod +x "${GOENV_TEST_DIR}/bin/go"
 
   GOENV_VERSION="system" run goenv-prefix
+  assert_success "$GOENV_TEST_DIR"
+}
+
+@test "system returns go if installed" {
+  mkdir -p "${GOENV_TEST_DIR}/bin"
+  touch "${GOENV_TEST_DIR}/bin/go"
+  chmod +x "${GOENV_TEST_DIR}/bin/go"
+
+  run goenv-prefix system
   assert_success "$GOENV_TEST_DIR"
 }
 
@@ -67,4 +80,53 @@ OUT
 @test "prints version from 'GOENV_VERSION' environment variable when no arguments are given" {
   GOENV_VERSION="1.2.3" run goenv-prefix
   assert_failure "goenv: version '1.2.3' not installed"
+}
+
+@test "goenv prefix displays properly sorted latest version when 'latest' version is given and any version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.10.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.10.9"
+  mkdir -p "${GOENV_ROOT}/versions/1.9.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.9.9"
+  run goenv-prefix latest
+  assert_success "${GOENV_ROOT}/versions/1.10.10"
+}
+
+@test "goenv prefix displays latest version when major version is given and any matching version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/4.5.6"
+  run goenv-prefix 1
+  assert_success "${GOENV_ROOT}/versions/1.2.10"
+}
+
+@test "goenv local fails setting latest version when major or minor single number is given and does not match at 'GOENV_ROOT/versions/<version>'" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/4.5.10"
+  run goenv-prefix 9
+  assert_failure "goenv: version '9' not installed"
+}
+
+@test "goenv prefix displays latest version when minor version is given as single number and any matching major.minor version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.2.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/1.3.11"
+  mkdir -p "${GOENV_ROOT}/versions/4.5.2"
+  run goenv-prefix 2
+  assert_success "${GOENV_ROOT}/versions/1.2.10"
+}
+
+@test "goenv prefix displays latest version when minor version is given as major.minor number and any matching version is installed" {
+  mkdir -p "${GOENV_ROOT}/versions/1.1.2"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.9"
+  mkdir -p "${GOENV_ROOT}/versions/1.2.10"
+  mkdir -p "${GOENV_ROOT}/versions/1.3.11"
+  mkdir -p "${GOENV_ROOT}/versions/2.1.2"
+  run goenv-prefix 1.2
+  assert_success "${GOENV_ROOT}/versions/1.2.10"
+}
+
+@test "goenv local fails setting latest version when major.minor number is given and does not match at 'GOENV_ROOT/versions/<version>'" {
+  mkdir -p "${GOENV_ROOT}/versions/1.1.9"
+  run goenv-prefix 1.9
+  assert_failure "goenv: version '1.9' not installed"
 }

--- a/test/goenv-rehash.bats
+++ b/test/goenv-rehash.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage rehash
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv rehash
 OUT
 }
@@ -50,7 +50,7 @@ OUT
   assert_success ""
 
   run /bin/ls "${GOENV_ROOT}/shims"
-  assert_success <<OUT
+  assert_success_out <<OUT
 go
 godoc
 OUT

--- a/test/goenv-root.bats
+++ b/test/goenv-root.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage root
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv root
 OUT
 }

--- a/test/goenv-sh-rehash.bats
+++ b/test/goenv-sh-rehash.bats
@@ -4,8 +4,8 @@ load test_helper
 
 @test "has usage instructions for goenv-sh-rehash" {
   run goenv-help --usage sh-rehash
-  assert_success <<OUT
-Usage: goenv sh-rehash
+  assert_success_out <<OUT
+Usage: goenv sh-rehash [--only-manage-paths]
 OUT
 }
 
@@ -68,7 +68,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
@@ -81,7 +81,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
@@ -94,7 +94,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
 OUT
@@ -107,7 +107,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=1 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 set -gx GOPATH "${HOME}/go/1.12.0"
 OUT
 }
@@ -119,7 +119,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
@@ -133,7 +133,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
@@ -147,7 +147,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
@@ -161,7 +161,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
@@ -175,7 +175,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
@@ -189,7 +189,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
@@ -203,7 +203,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
@@ -217,7 +217,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="${HOME}/go/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
@@ -231,7 +231,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:${HOME}/go/1.12.0"
 hash -r 2>/dev/null || true
@@ -245,7 +245,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "${HOME}/go/1.12.0"
 OUT
@@ -258,7 +258,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "${HOME}/go/1.12.0:/fake-gopath"
 OUT
@@ -271,7 +271,7 @@ OUT
 
   GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "/fake-gopath:${HOME}/go/1.12.0"
 OUT
@@ -284,7 +284,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
@@ -298,7 +298,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
@@ -312,7 +312,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
@@ -326,7 +326,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
@@ -340,7 +340,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
@@ -354,7 +354,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
@@ -368,7 +368,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
@@ -382,7 +382,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/tmp/example/1.12.0:/fake-gopath"
 hash -r 2>/dev/null || true
@@ -396,7 +396,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 export GOROOT="$(GOENV_VERSION=1.12.0 goenv-prefix)"
 export GOPATH="/fake-gopath:/tmp/example/1.12.0"
 hash -r 2>/dev/null || true
@@ -410,7 +410,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "/tmp/example/1.12.0"
 OUT
@@ -423,7 +423,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_APPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "/tmp/example/1.12.0:/fake-gopath"
 OUT
@@ -436,7 +436,7 @@ OUT
 
   GOENV_GOPATH_PREFIX=/tmp/example GOENV_VERSION=1.12.0 GOENV_DISABLE_GOROOT=0 GOENV_DISABLE_GOPATH=0 GOENV_PREPEND_GOPATH=1 GOPATH='/fake-gopath' run goenv-sh-rehash
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 set -gx GOROOT "$(GOENV_VERSION=1.12.0 goenv-prefix)"
 set -gx GOPATH "/fake-gopath:/tmp/example/1.12.0"
 OUT
@@ -483,7 +483,7 @@ OUT
   assert_success ""
 
   run /bin/ls "${GOENV_ROOT}/shims"
-  assert_success <<OUT
+  assert_success_out <<OUT
 go
 godoc
 OUT
@@ -599,7 +599,7 @@ OUT
   assert_success ""
 
   run /bin/ls "${GOENV_ROOT}/shims"
-  assert_success <<OUT
+  assert_success_out <<OUT
 go
 OUT
 

--- a/test/goenv-sh-shell.bats
+++ b/test/goenv-sh-shell.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage shell
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv shell <version>
        goenv shell --unset
 OUT
@@ -12,7 +12,7 @@ OUT
 
 @test "has completion support" {
   run goenv-sh-shell --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 --unset
 system
 OUT
@@ -83,7 +83,7 @@ OUT
 @test "fails changing 'GOENV_VERSION' environment variable to specified shell version argument if version does not exist in GOENV_ROOT/versions/<version>" {
   GOENV_SHELL=bash run goenv-sh-shell 1.2.3
 
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 goenv: version '1.2.3' not installed
 false
 OUT

--- a/test/goenv-shims.bats
+++ b/test/goenv-shims.bats
@@ -4,14 +4,14 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage shims
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv shims [--short]
 OUT
 }
 
 @test "has completion support" {
   run goenv-shims --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 --short
 OUT
 }
@@ -30,7 +30,7 @@ OUT
 
   run goenv-shims
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 ${GOENV_ROOT}/shims/go
 ${GOENV_ROOT}/shims/godoc
 ${GOENV_ROOT}/shims/gofmt
@@ -46,7 +46,7 @@ OUT
 
   run goenv-shims --short
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 go
 godoc
 gofmt

--- a/test/goenv-version-file-read.bats
+++ b/test/goenv-version-file-read.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version-file-read
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv version-file-read <file>
 OUT
 }

--- a/test/goenv-version-file-write.bats
+++ b/test/goenv-version-file-write.bats
@@ -9,18 +9,18 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version-file-write
-  assert_success <<OUT
-Usage: goenv version-file-write <file> <version>
+  assert_success_out <<OUT
+Usage: goenv version-file-write <file> <version>...
 OUT
 }
 
 @test "prints usage instructions when 2 arguments aren't specified" {
   run goenv-version-file-write
 
-  assert_failure "Usage: goenv version-file-write <file> <version>"
+  assert_failure "Usage: goenv version-file-write <file> <version>..."
 
   run goenv-version-file-write "one"
-  assert_failure "Usage: goenv version-file-write <file> <version>"
+  assert_failure "Usage: goenv version-file-write <file> <version>..."
 }
 
 @test "fails when 2 arguments are specified, but version is non-existent" {

--- a/test/goenv-version-file.bats
+++ b/test/goenv-version-file.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version-file
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv version-file [<dir>]
 OUT
 }

--- a/test/goenv-version-name.bats
+++ b/test/goenv-version-name.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version-name
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv version-name
 OUT
 }
@@ -100,7 +100,7 @@ SH
   # NOTE: Test with last version specified is missing
   GOENV_VERSION="1.11.1:1.10.3" run goenv-version-name
 
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 goenv: version '1.10.3' is not installed (set by GOENV_VERSION environment variable)
 1.11.1
 OUT
@@ -108,7 +108,7 @@ OUT
   # NOTE: Test with first version specified is missing
   GOENV_VERSION="1.10.3:1.11.1" run goenv-version-name
 
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 goenv: version '1.10.3' is not installed (set by GOENV_VERSION environment variable)
 1.11.1
 OUT

--- a/test/goenv-version-origin.bats
+++ b/test/goenv-version-origin.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version-origin
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv version-origin
 OUT
 }

--- a/test/goenv-version.bats
+++ b/test/goenv-version.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "has usage instructions" {
   run goenv-help --usage version
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv version
 OUT
 }
@@ -51,7 +51,7 @@ OUT
   echo "1.11.1:1.10.3" >"${GOENV_ROOT}/version"
 
   run goenv-version
-  assert_success <<OUT
+  assert_success_out <<OUT
 1.11.1 (set by ${GOENV_ROOT}/version)
 1.10.3 (set by ${GOENV_ROOT}/version)
 OUT
@@ -61,7 +61,7 @@ OUT
   create_version "1.11.1"
 
   GOENV_VERSION=1.1:1.11.1:1.2 run goenv-version
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 goenv: version '1.1' is not installed (set by GOENV_VERSION environment variable)
 goenv: version '1.2' is not installed (set by GOENV_VERSION environment variable)
 1.11.1 (set by GOENV_VERSION environment variable)
@@ -74,7 +74,7 @@ OUT
   create_version "1.11.1"
 
   GOENV_VERSION=1.1:1.11.1:1.2 run goenv-version
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 goenv: version '1.1' is not installed (set by GOENV_VERSION environment variable)
 goenv: version '1.2' is not installed (set by GOENV_VERSION environment variable)
 1.11.1 (set by GOENV_VERSION environment variable)

--- a/test/goenv-versions.bats
+++ b/test/goenv-versions.bats
@@ -15,14 +15,14 @@ stub_system_go() {
 
 @test "has usage instructions" {
   run goenv-help --usage versions
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv versions [--bare] [--skip-aliases]
 OUT
 }
 
 @test "has completion support" {
   run goenv-versions --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 --bare
 --skip-aliases
 OUT
@@ -30,7 +30,7 @@ OUT
 
 @test "prints usage instructions when unknown arguments are given" {
   run goenv-versions magic and more
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 Usage: goenv versions [--bare] [--skip-aliases]
 OUT
 }
@@ -71,7 +71,7 @@ OUT
   create_version "1.10.1"
   run goenv-versions
 
-  assert_success <<OUT
+  assert_success_out <<OUT
 * system (set by ${GOENV_ROOT}/version)
   1.10.1
   1.10.2
@@ -83,7 +83,7 @@ OUT
   create_version "1.10.3"
   run goenv-versions
 
-  assert_success <<OUT
+  assert_success_out <<OUT
   1.10.3
 OUT
 }
@@ -101,7 +101,7 @@ OUT
   create_version "1.11.1"
 
   GOENV_VERSION=1.10.1 run goenv-versions
-  assert_success <<OUT
+  assert_success_out <<OUT
   system
 * 1.10.1 (set by GOENV_VERSION environment variable)
   1.11.1
@@ -112,7 +112,7 @@ OUT
   create_version "1.10.3"
   create_version "1.11.1"
   GOENV_VERSION=1.10.3 run goenv-versions --bare
-  assert_success <<OUT
+  assert_success_out <<OUT
 1.10.3
 1.11.1
 OUT
@@ -126,7 +126,7 @@ OUT
   echo "1.11.1" > "${GOENV_ROOT}/version"
   run goenv-versions
 
-  assert_success <<OUT
+  assert_success_out <<OUT
   system
   1.10.3
 * 1.11.1 (set by ${GOENV_ROOT}/version)
@@ -141,7 +141,7 @@ OUT
   echo "1.6.1" > '.go-version'
 
   run goenv-versions
-  assert_success <<OUT
+  assert_success_out <<OUT
   system
 * 1.6.1 (set by ${GOENV_TEST_DIR}/.go-version)
   1.8.4
@@ -153,7 +153,7 @@ OUT
   touch "${GOENV_ROOT}/versions/hello"
 
   run goenv-versions
-  assert_success <<OUT
+  assert_success_out <<OUT
   1.8.4
 OUT
 }
@@ -163,7 +163,7 @@ OUT
   ln -s "1.8.3" "${GOENV_ROOT}/versions/1.8.4"
 
   run goenv-versions
-  assert_success <<OUT
+  assert_success_out <<OUT
   1.8.3
   1.8.4
 OUT
@@ -174,7 +174,7 @@ OUT
   ln -s "1.8.3" "${GOENV_ROOT}/versions/1.8.4"
 
   run goenv-versions --skip-aliases
-  assert_success <<OUT
+  assert_success_out <<OUT
   1.8.3
 OUT
 }

--- a/test/goenv-whence.bats
+++ b/test/goenv-whence.bats
@@ -4,14 +4,14 @@ load test_helper
 
 @test "has usage instructions" {
   run goenv-help --usage whence
-  assert_success <<OUT
+  assert_success_out <<OUT
 Usage: goenv whence [--path] <command>
 OUT
 }
 
 @test "has completion support" {
   run goenv-whence --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 --path
 OUT
 }
@@ -19,7 +19,7 @@ OUT
 @test "fails and prints usage when no argument is given" {
   run goenv-whence
 
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 Usage: goenv whence [--path] <command>
 OUT
 }
@@ -29,7 +29,7 @@ OUT
   create_executable "1.6.1" "go"
 
   run goenv-whence go
-  assert_success <<OUT
+  assert_success_out <<OUT
 1.6.0
 1.6.1
 OUT
@@ -40,7 +40,7 @@ OUT
   create_executable "1.6.1" "go"
 
   run goenv-whence --path go
-  assert_success <<OUT
+  assert_success_out <<OUT
 ${GOENV_ROOT}/versions/1.6.0/bin/go
 ${GOENV_ROOT}/versions/1.6.1/bin/go
 OUT
@@ -54,7 +54,7 @@ OUT
   create_executable "1.6.1" "go"
 
   run goenv-whence go
-  assert_success <<OUT
+  assert_success_out <<OUT
 1.6.1
 OUT
 }

--- a/test/goenv-which.bats
+++ b/test/goenv-which.bats
@@ -46,7 +46,7 @@ load test_helper
 
 @test "fails when specified versions separated by ':' from 'GOENV_VERSION' environment variable are not installed" {
   GOENV_VERSION=1.10.3:1.11.1 run goenv-which go
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 goenv: version '1.10.3' is not installed (set by GOENV_VERSION environment variable)
 goenv: version '1.11.1' is not installed (set by GOENV_VERSION environment variable)
 OUT
@@ -70,7 +70,7 @@ OUT
   create_executable "1.11.1" "gofmt"
 
   GOENV_VERSION=1.4.0 run -127 goenv-which gofmt
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 goenv: 'gofmt' command not found
 
 The 'gofmt' command exists in these Go versions:

--- a/test/goenv.bats
+++ b/test/goenv.bats
@@ -11,7 +11,7 @@ teardown() {
   mkdir -p "${GOENV_ROOT}/versions/1.10.9"
   mkdir -p "${GOENV_ROOT}/versions/1.9.10"
   run goenv --complete
-  assert_success <<OUT
+  assert_success_out <<OUT
 1.10.9
 1.9.10
 commands
@@ -46,7 +46,7 @@ OUT
 
 @test "fails and prints help when no command argument is given" {
   run goenv
-  assert_failure <<OUT
+  assert_failure_out <<OUT
 $(goenv---version)
 Usage: goenv <command> [<args>]
 
@@ -77,7 +77,7 @@ OUT
 
   unset GOENV_AUTO_INSTALL
   
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 Usage: goenv install [-f] [-kvpq] <version>|latest|unstable
        goenv install [-f] [-kvpq] <definition-file>
        goenv install -l|--list
@@ -172,10 +172,10 @@ OUT
   assert_success "${GOENV_ROOT}/goenv.d:${BATS_TEST_DIRNAME%/*}/goenv.d:/usr/local/etc/goenv.d:/etc/goenv.d:/usr/lib/goenv/hooks"
 }
 
-@test "prints error when called with 'shell' subcommand, but $(GOENV_SHELL) environment variable is not present" {
+@test "prints error when called with 'shell' subcommand, but GOENV_SHELL environment variable is not present" {
   unset GOENV_SHELL
   run goenv shell
-  assert_failure <<OUT
+  assert_failure_out <<'OUT'
 eval "$(goenv init -)" has not been executed.
 Please read the installation instructions in the README.md at github.com/go-nv/goenv
 or run 'goenv help init' for more information

--- a/test/test_assert_helpers.bash
+++ b/test/test_assert_helpers.bash
@@ -15,11 +15,31 @@ assert_success() {
   fi
 }
 
+assert_success_out() {
+  if [ "$status" -ne 0 ]; then
+    flunk "command failed with exit status $status"
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  else
+    assert_output
+  fi
+}
+
 assert_failure() {
   if [ "$status" -eq 0 ]; then
     flunk "expected failed exit status"
   elif [ "$#" -gt 0 ]; then
     assert_output "$1"
+  fi
+}
+
+assert_failure_out() {
+  if [ "$status" -eq 0 ]; then
+    flunk "expected failed exit status"
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  else
+    assert_output
   fi
 }
 


### PR DESCRIPTION
### Features
* `goenv prefix` supports the same `installed` version identifiers like `local` or `global`
* `goenv prefix latest` -> 1.22.3 (latest installed version)
* `goenv prefix system` -> system Go location if installed
* `goenv prefix 1` -> 1.22.3 (latest installed major version)
* `goenv prefix 22` -> 1.22.3 (latest installed minor version when combined with a major version)
* `goenv prefix 1.22` -> 1.22.3 (latest installed minor version)
* Offer all installed versions plus `latest` and `system` as completions

### Fixes
* Usage information and tests by introducing new helper functions

### Changed
* `Using latest patch version` no longer displayed (prefix contains the found version already)