### PR TITLE
fix: Restore support for release candidates

### DIFF
--- a/libexec/goenv-installed
+++ b/libexec/goenv-installed
@@ -22,7 +22,6 @@ if [ "$1" = "--complete" ]; then
   exec goenv-versions --bare
 fi
 
-#majors=({2,1}) # Supported Go versions: 2,1 (latest first)
 majors=({1,}) # Supported Go versions: 1 (latest first)
 
 versions() {
@@ -40,8 +39,10 @@ latest_major() {
 }
 
 latest_minor() {
+  [[ "$1" =~ ^([0-9]+\.[0-9]+rc)[0-9]+ ]] && minor="${BASH_REMATCH[1]}" || minor="$1"
+  # 1.23rc1 -> latest release candidate 1.23rc2
   # 1.23 -> latest minor 1.23.4
-  versions | grep -oE "^$(regex "$1")\\.([0-9]+)$" | tail -1
+  versions | grep -oE "^$(regex "$minor")\\.([0-9]+)$" | tail -1
 }
 
 installed() {
@@ -82,7 +83,8 @@ fi
 
 # Check version=1 (major without minor and patch) => 1.23.4 (latest major version)
 # Or version=23 (minor without major and patch) => 1.23.4 (latest patch version)
-if grep -q -E "^[0-9]+(\s*)$" <<<"${version}"; then
+# Or version=23rc1 (minor with release candidate) => 1.23rc2 (latest release candidate version)
+if grep -q -E "^[0-9]+(rc[0-9]+)?(\s*)$" <<<"${version}"; then
   for major in "${majors[@]}"; do
     if [ "$version" = "$major" ]; then
       LATEST_MAJOR=$(latest_major "$version")
@@ -101,7 +103,8 @@ if grep -q -E "^[0-9]+(\s*)$" <<<"${version}"; then
 fi
 
 # Check version=1.23 (minor without patch) => 1.23.4 (latest patch version)
-if grep -q -E "^[0-9]+\.[0-9]+(\s*)$" <<<"${version}"; then
+# Or version=1.23rc1 (minor with release candidate) => 1.23rc2 (latest release candidate version)
+if grep -q -E "^[0-9]+\.[0-9]+(rc[0-9]+)?(\s*)$" <<<"${version}"; then
   LATEST_MINOR=$(latest_minor "$version")
   if [ -n "$LATEST_MINOR" ]; then
     echo "$LATEST_MINOR"

--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -22,6 +22,8 @@ exec 3<&2 # preserve original stderr at fd 3
 # Verbose output in debug mode
 [ -n "$GOENV_DEBUG" ] && set -x
 
+majors=({1,}) # Supported Go versions: 1 (latest first)
+
 lib() {
   parse_options() {
     OPTIONS=()
@@ -767,7 +769,9 @@ sort_versions() {
 }
 
 latest_version() {
-  list_definitions | grep -oE "^$1\\.([0-9]+)?" | tail -1
+  # Find latest release candidate or patch version
+  [[ "$1" =~ ^([0-9]+\.[0-9]+rc)[0-9]+ ]] && minor="${BASH_REMATCH[1]}" || minor="$1."
+  list_definitions | grep -F "$minor" | tail -1
 }
 
 unset VERBOSE
@@ -828,13 +832,15 @@ done
 
 [ "${#ARGUMENTS[@]}" -eq 2 ] || usage 1 >&2
 
-DEFINITION_PATH="${ARGUMENTS[0]}"
+# Prepend major version if needed
+# 20rc1 -> 1.20rc1
+# 22 -> 1.22
+[[ "${ARGUMENTS[0]}" =~ ^[0-9]+(rc[0-9]+)?$ ]] && DEFINITION_PATH="${majors[0]}.${ARGUMENTS[0]}" || DEFINITION_PATH="${ARGUMENTS[0]}"
 
 # The latest patch version will be located, e.g if 1.11 is supplied they'll be changed to `1.11.x`.
 # NOTE: Try to capture semantic versions such as `1.11` which don't have a patch version and install latest patch.
-if grep -q -E "^[0-9]+\.[0-9]+(\s*)$" <<<${DEFINITION_PATH}; then
-  REGEX=$(echo $DEFINITION_PATH | sed s/\\./\\\\./)
-  LATEST_PATCH=$(latest_version $REGEX)
+if grep -q -E "^[0-9]+\.[0-9]+(rc[0-9]+)(\s*)$" <<<${DEFINITION_PATH}; then
+  LATEST_PATCH=$(latest_version $DEFINITION_PATH)
   echo "Using latest patch version $LATEST_PATCH"
   DEFINITION_PATH="$LATEST_PATCH"
 fi


### PR DESCRIPTION
### Fixes
* Restore support for release candidates in `local`, `global`, `install` and `installed`

### Examples
* `install 20rc1` installs 1.20rc2 (using latest release candidate like for minor versions)

### Please note
* There are no tests yet
* `install 1.20rc1` installs the latest release candidate rc2, like it does for other minor versions (1.22 installs 1.22.6)
* goenv supports only a fraction of release candidates (it doesn't sync them like final releases)
* goenv does not allow installing an arbitrary version (unknown to goenv hashsums in `plugins/go-build/share/go-build`)