### PR TITLE
Fix warning from sha256sum, sha1sum

### DIFF
--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -353,7 +353,7 @@ compute_sha2() {
     output="$("$openssl" dgst -sha256 2>/dev/null)" || return 1
     echo "${output##* }"
   elif type sha256sum &>/dev/null; then
-    output="$(sha256sum --quiet)" || return 1
+    output="$(sha256sum)" || return 1
     echo "${output% *}"
   else
     return 1
@@ -370,7 +370,7 @@ compute_sha1() {
     output="$("$openssl" dgst -sha1 2>/dev/null)" || return 1
     echo "${output##* }"
   elif type sha1sum &>/dev/null; then
-    output="$(sha1sum --quiet)" || return 1
+    output="$(sha1sum)" || return 1
     echo "${output% *}"
   else
     return 1


### PR DESCRIPTION
When sha256sum is run, I can see that it complains about the use of the --quiet flag, which does not have any effect when not verifying two checksums match.

    $ goenv install 1.23.1
    sha256sum: the --quiet option is meaningful only when 
    verifying checksums
    Try 'sha256sum --help' for more information.
    Downloading go1.23.1.linux-arm64.tar.gz...

This can be shown outside goenv as well for both the sha256sum and sha1sum facilities on my device.
For example:

    ➜  ~ echo test | sha256sum --quiet
    sha256sum: the --quiet option is meaningful only when 
    verifying checksums
    Try 'sha256sum --help' for more information.
    ➜  ~ echo $?
    1
    ➜  ~ echo test | sha256sum 
    f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2  -
    ➜  ~ echo $?
    0
    ➜  ~ sha256sum --version
    sha256sum (GNU coreutils) 9.5
    Copyright (C) 2024 Free Software Foundation, Inc.
    License GPLv3+: GNU GPL version 3 or later  <https://gnu.org/licenses/gpl.html>.
    This is free software: you are free to change and redistribute it.
    There is NO WARRANTY, to the extent permitted by law.

    Written by Ulrich Drepper, Scott Miller, and David Madore.

This commit removes the use of the quiet flag for sha256sum and sha1sum usages.