### PR TITLE
sanitize whitespace from checksums

### DIFF
--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -408,7 +408,7 @@ has_checksum_support() {
 verify_checksum() {
   local checksum_command
   local filename="$1"
-  local expected_checksum="$(echo "$2" | tr [A-Z] [a-z])"
+  local expected_checksum="$(echo "$2" | tr [A-Z] [a-z] | tr -d '[:space:]')"
 
   # If the specified filename doesn't exist, return success
   [ -e "$filename" ] || return 0
@@ -433,7 +433,7 @@ verify_checksum() {
   has_checksum_support "$checksum_command" || return 0
 
   # If the computed checksum is empty, return failure
-  local computed_checksum=$(echo "$($checksum_command <"$filename")" | tr [A-Z] [a-z])
+  local computed_checksum=$(echo "$($checksum_command <"$filename")" | tr [A-Z] [a-z] | tr -d '[:space:]')
   [ -n "$computed_checksum" ] || return 1
 
   if [ "$expected_checksum" != "$computed_checksum" ]; then


### PR DESCRIPTION
As reported in #403 version 2.2.7 has broken `goenv` on certain operating systems / environment e.g. AWS build images.

The PR #401 made `sha256sum` functional again but exposed a white-space comparison issue i.e. on systems using sha256sum would eventually lead to a failure in `verify_checksum` i.e.

```
+++++ sha256sum
++++ output='542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e  -'
++++ echo '542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e '
+++ echo '542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e '
++ local 'computed_checksum=542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e '
++ '[' -n '542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e ' ']'
++ '[' 542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e '!=' '542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e ' ']'
++ echo 'checksum mismatch: Go Linux 64bit 1.23.2.tar.gz (file is corrupt)'
checksum mismatch: Go Linux 64bit 1.23.2.tar.gz (file is corrupt)
++ echo 'expected 542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e, got 542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e '
expected 542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e, got 542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e 
```

This impact Redhat derivatives OS e.g. amazon linux as their git/perl default install doesn't install the perl package Digest-SHA  which includes the `shasum` command by default ( which `goenv` uses in preference to `sha256sum`).  debian based OS's will ship with `Digest-SHA` as part of their base install ( pulled in via git packages).

Installing `perl-Digest-SHA` on a build image gets goenv working again on 2.2.7 , but the longer term fix is to ensure the checksums are sanitized prior to comparison in a similar way how the chars are lower-cased.

