### PR TITLE
dont use the user's paths. Instead use compgen

### DIFF
--- a/libexec/goenv-commands
+++ b/libexec/goenv-commands
@@ -20,8 +20,6 @@ elif [ "$1" = "--no-sh" ]; then
   shift
 fi
 
-IFS=: paths=($PATH)
-
 shopt -s nullglob
 
 {
@@ -35,21 +33,19 @@ shopt -s nullglob
     goenv-versions --bare
   fi
 
-  for path in "${paths[@]}"; do
-    for command in "${path}/goenv-"*; do
-      [ -x "$command" ] || continue
-      command="${command##*/goenv-}"
-      if [ -n "$sh" ]; then
-        if [ ${command:0:3} == "sh-" ]; then
-          echo "${command##sh-}"
-        fi
-      elif [ -n "$nosh" ]; then
-        if [ ${command:0:3} != "sh-" ]; then
-          echo "${command##sh-}"
-        fi
-      else
+  for command in $(compgen -c goenv-); do
+    [ -x "$(command -v "$command")" ] || continue
+    command="${command##goenv-}"
+    if [ -n "$sh" ]; then
+      if [[ ${command:0:3} == "sh-" ]]; then
         echo "${command##sh-}"
       fi
-    done
+    elif [ -n "$nosh" ]; then
+      if [[ ${command:0:3} != "sh-" ]]; then
+        echo "${command##sh-}"
+      fi
+    else
+      echo "${command##sh-}"
+    fi
   done
 } | sort | uniq | grep -v -E '^(echo|--version|realpath\.dylib)$'


### PR DESCRIPTION
Eliminate the need for iterating over the user's paths to search for `goenv-`