### PR TITLE
goenv-init: Fix use of optional variables that should not crash the calling shell if unset

### DIFF
--- a/libexec/goenv-init
+++ b/libexec/goenv-init
@@ -108,14 +108,14 @@ EOL
   cat <<EOL
 export GOENV_SHELL=${shell}
 export GOENV_ROOT=${GOENV_ROOT}
-if [ -z "\${GOENV_RC_FILE}" ]; then
+if [ -z "\${GOENV_RC_FILE:-}" ]; then
   GOENV_RC_FILE="\${HOME}/.goenvrc"
 fi
-if [ -e "\${GOENV_RC_FILE}" ]; then
+if [ -e "\${GOENV_RC_FILE:-}" ]; then
   source "\${GOENV_RC_FILE}"
 fi
 if [ "\${PATH#*\$GOENV_ROOT/shims}" = "\${PATH}" ]; then
-  if [ "\${GOENV_PATH_ORDER}" = "front" ] ; then
+  if [ "\${GOENV_PATH_ORDER:-}" = "front" ] ; then
     export PATH="\${GOENV_ROOT}/shims:\${PATH}"
   else
     export PATH="\${PATH}:\${GOENV_ROOT}/shims"

--- a/test/goenv-init.bats
+++ b/test/goenv-init.bats
@@ -135,14 +135,14 @@ OUT
 
   assert_line 0  'export GOENV_SHELL=bash'
   assert_line 1  "export GOENV_ROOT=$GOENV_ROOT"
-  assert_line 2  'if [ -z "${GOENV_RC_FILE}" ]; then'
+  assert_line 2  'if [ -z "${GOENV_RC_FILE:-}" ]; then'
   assert_line 3  '  GOENV_RC_FILE="${HOME}/.goenvrc"'
   assert_line 4  'fi'
-  assert_line 5  'if [ -e "${GOENV_RC_FILE}" ]; then'
+  assert_line 5  'if [ -e "${GOENV_RC_FILE:-}" ]; then'
   assert_line 6  '  source "${GOENV_RC_FILE}"'
   assert_line 7  'fi'
   assert_line 8  'if [ "${PATH#*$GOENV_ROOT/shims}" = "${PATH}" ]; then'
-  assert_line 9  '  if [ "${GOENV_PATH_ORDER}" = "front" ] ; then'
+  assert_line 9  '  if [ "${GOENV_PATH_ORDER:-}" = "front" ] ; then'
   assert_line 10 '    export PATH="${GOENV_ROOT}/shims:${PATH}"'
   assert_line 11 '  else'
   assert_line 12 '    export PATH="${PATH}:${GOENV_ROOT}/shims"'
@@ -173,14 +173,14 @@ OUT
 
   assert_line 0  'export GOENV_SHELL=zsh'
   assert_line 1  "export GOENV_ROOT=$GOENV_ROOT"
-  assert_line 2  'if [ -z "${GOENV_RC_FILE}" ]; then'
+  assert_line 2  'if [ -z "${GOENV_RC_FILE:-}" ]; then'
   assert_line 3  '  GOENV_RC_FILE="${HOME}/.goenvrc"'
   assert_line 4  'fi'
-  assert_line 5  'if [ -e "${GOENV_RC_FILE}" ]; then'
+  assert_line 5  'if [ -e "${GOENV_RC_FILE:-}" ]; then'
   assert_line 6  '  source "${GOENV_RC_FILE}"'
   assert_line 7  'fi'
   assert_line 8  'if [ "${PATH#*$GOENV_ROOT/shims}" = "${PATH}" ]; then'
-  assert_line 9  '  if [ "${GOENV_PATH_ORDER}" = "front" ] ; then'
+  assert_line 9  '  if [ "${GOENV_PATH_ORDER:-}" = "front" ] ; then'
   assert_line 10 '    export PATH="${GOENV_ROOT}/shims:${PATH}"'
   assert_line 11 '  else'
   assert_line 12 '    export PATH="${PATH}:${GOENV_ROOT}/shims"'
@@ -244,14 +244,14 @@ OUT
 
   assert_line 0  'export GOENV_SHELL=ksh'
   assert_line 1  "export GOENV_ROOT=$GOENV_ROOT"
-  assert_line 2  'if [ -z "${GOENV_RC_FILE}" ]; then'
+  assert_line 2  'if [ -z "${GOENV_RC_FILE:-}" ]; then'
   assert_line 3  '  GOENV_RC_FILE="${HOME}/.goenvrc"'
   assert_line 4  'fi'
-  assert_line 5  'if [ -e "${GOENV_RC_FILE}" ]; then'
+  assert_line 5  'if [ -e "${GOENV_RC_FILE:-}" ]; then'
   assert_line 6  '  source "${GOENV_RC_FILE}"'
   assert_line 7  'fi'
   assert_line 8  'if [ "${PATH#*$GOENV_ROOT/shims}" = "${PATH}" ]; then'
-  assert_line 9  '  if [ "${GOENV_PATH_ORDER}" = "front" ] ; then'
+  assert_line 9  '  if [ "${GOENV_PATH_ORDER:-}" = "front" ] ; then'
   assert_line 10 '    export PATH="${GOENV_ROOT}/shims:${PATH}"'
   assert_line 11 '  else'
   assert_line 12 '    export PATH="${PATH}:${GOENV_ROOT}/shims"'
@@ -281,14 +281,14 @@ OUT
   # NOTE: This is very likely to be invalid for your specific shell
   assert_line 0  'export GOENV_SHELL=magicshell'
   assert_line 1  "export GOENV_ROOT=$GOENV_ROOT"
-  assert_line 2  'if [ -z "${GOENV_RC_FILE}" ]; then'
+  assert_line 2  'if [ -z "${GOENV_RC_FILE:-}" ]; then'
   assert_line 3  '  GOENV_RC_FILE="${HOME}/.goenvrc"'
   assert_line 4  'fi'
-  assert_line 5  'if [ -e "${GOENV_RC_FILE}" ]; then'
+  assert_line 5  'if [ -e "${GOENV_RC_FILE:-}" ]; then'
   assert_line 6  '  source "${GOENV_RC_FILE}"'
   assert_line 7  'fi'
   assert_line 8  'if [ "${PATH#*$GOENV_ROOT/shims}" = "${PATH}" ]; then'
-  assert_line 9  '  if [ "${GOENV_PATH_ORDER}" = "front" ] ; then'
+  assert_line 9  '  if [ "${GOENV_PATH_ORDER:-}" = "front" ] ; then'
   assert_line 10 '    export PATH="${GOENV_ROOT}/shims:${PATH}"'
   assert_line 11 '  else'
   assert_line 12 '    export PATH="${PATH}:${GOENV_ROOT}/shims"'
@@ -311,4 +311,3 @@ OUT
 
   assert_success
 }
-


### PR DESCRIPTION
Just use the ${variable:-} syntax to accept unset variables

Our Yunohost helper is broken since the 2.2.10 because we source goenv-init with `set -u` and we don't define the optional environment variables.