### PR TITLE
fix: missing exclusion of rehash on init

### DIFF
--- a/libexec/goenv-init
+++ b/libexec/goenv-init
@@ -183,7 +183,9 @@ if [ "$shell" != "fish" ]; then
 EOS
 fi
 
-# NOTE: Rehash again, but only to export managed paths
-cat <<EOS
-goenv rehash --only-manage-paths
+if [ -z "$no_rehash" ]; then
+  # NOTE: Rehash again, but only to export managed paths
+  cat <<EOS
+  goenv rehash --only-manage-paths
 EOS
+fi


### PR DESCRIPTION
Cut time by 75%

~ via 🐹 v1.23.4 via 🐍 v3.12.8 (main) on ☁️
➜  time eval "$(goenv init -)"

real	0m0.755s
user	0m0.138s
sys		0m0.207s

~ via 🐹 v1.23.4 via 🐍 v3.12.8 (main) on ☁️
➜  time eval "$(goenv init - --no-rehash)"

real	0m0.407s
user	0m0.099s
sys		0m0.140s

After fix:

~ via 🐹 v1.23.4 via 🐍 v3.12.8 (main) on ☁️
➜  time eval "$(goenv init - --no-rehash)"

real	0m0.133s
user	0m0.032s
sys		0m0.051s

Signed-off-by: Justin Lecher <justin.lecher@astrazeneca.com>
