### PR TITLE
Make AWS Codebuild instructions simpler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ The following snippet can be inserted in your buildspec.yml (or buildspec defini
 **Side Note:** if you use the below steps, please unset your golang version in the buildspec and run the installer manually.
 
 ```yaml
-- BUILD_DIR=$PWD
-- cd /root/.goenv/plugins/go-build/../.. && git pull && cd -
-- cd $BUILD_DIR
+- (cd /root/.goenv/plugins/go-build/../.. && git pull)
 ```
 
 ---


### PR DESCRIPTION
No need to manually record PWD and to change back to previous directory if you let a subshell do it for you.

Fixes https://github.com/go-nv/goenv/issues/458