### PR TITLE
fix(cve-2022-35861): backport pyenv fix

### DIFF
--- a/libexec/goenv-version-file-read
+++ b/libexec/goenv-version-file-read
@@ -27,7 +27,19 @@ else
   IFS="${IFS}"$'\r'
   words=($(cut -b 1-1024 "$VERSION_FILE" | sed -n 's/^[[:space:]]*\([^[:space:]#][^[:space:]]*\).*/\1/p'))
 
-  versions=("${words[@]}")
+  # Filter out potentially malicious version strings to prevent path traversal (CVE-2022-35861)
+  versions=()
+  for word in "${words[@]}"; do
+    if [[ -z "$word" || "$word" == \#* ]]; then
+      # Skip empty lines and comments
+      continue
+    elif [[ "$word" == ".." ]] || [[ "$word" == */* ]]; then
+      # The version string is used to construct a path and we skip dubious values.
+      # This prevents issues such as path traversal (CVE-2022-35861).
+      continue
+    fi
+    versions=("${versions[@]}" "$word")
+  done
 fi
 
 if [ ! -n "$versions" ]; then

--- a/test/goenv-version-file-read.bats
+++ b/test/goenv-version-file-read.bats
@@ -109,3 +109,16 @@ IN
   run goenv-version-file-read my-version
   assert_success "1.11.1"
 }
+
+@test "skips relative path traversal" {
+  cat >my-version <<IN
+1.11.1
+1.10.8
+..
+./*
+1.9.7
+IN
+
+  run goenv-version-file-read my-version
+  assert_success "1.11.1:1.10.8:1.9.7"
+}


### PR DESCRIPTION
Kudos to @CharlyReux and @RomainLefeuvre for spotting this and suggesting the fix.