### PR TITLE
fix(init): Update 'read -ra' to 'read -rA' in zsh fixing invalid option errors

### DIFF
--- a/cmd/shell/init.go
+++ b/cmd/shell/init.go
@@ -298,7 +298,11 @@ func renderInitScript(shell shellutil.ShellType, cfg *config.Config, noRehash bo
 		// Clean up any version bin directories from PATH (e.g., from venv capture)
 		builder.WriteString("# Remove any goenv version bin directories from PATH\n")
 		builder.WriteString("_NEW_PATH=\"\"\n")
-		builder.WriteString("while IFS=: read -ra PATHARRAY; do\n")
+		if shell == shellutil.ShellTypeZsh {
+			builder.WriteString("while IFS=: read -rA PATHARRAY; do\n") // required captial A for zsh read command
+		} else {
+			builder.WriteString("while IFS=: read -ra PATHARRAY; do\n")
+		}
 		builder.WriteString("  for i in \"${PATHARRAY[@]}\"; do\n")
 		builder.WriteString("    case \"$i\" in\n")
 		builder.WriteString("      \"$GOENV_ROOT\"/versions/*/bin) ;;\n")
@@ -310,7 +314,11 @@ func renderInitScript(shell shellutil.ShellType, cfg *config.Config, noRehash bo
 		builder.WriteString("unset _NEW_PATH\n")
 		builder.WriteString("# Remove shims from PATH if present (to re-add in correct position)\n")
 		builder.WriteString("_NEW_PATH=\"\"\n")
-		builder.WriteString("while IFS=: read -ra PATHARRAY; do\n")
+		if shell == shellutil.ShellTypeZsh {
+			builder.WriteString("while IFS=: read -rA PATHARRAY; do\n") // required captial A for zsh read command
+		} else {
+			builder.WriteString("while IFS=: read -ra PATHARRAY; do\n")
+		}
 		builder.WriteString("  for i in \"${PATHARRAY[@]}\"; do\n")
 		builder.WriteString("    case \"$i\" in\n")
 		builder.WriteString("      \"$GOENV_ROOT\"/shims) ;;\n")


### PR DESCRIPTION
Problem:
---
Current 3.1.0 release fails to load `goenv init -` on zsh due to incorrect `read` command argument

Example:
----
```
(eval):read:11: bad option: -a
(eval):read:23: bad option: -a
```

Resolution:
---
Took path of least resistance making comparison at specific commands instead of duplicating entire `default` case

Testing:
---
Tested on MacOS 26.5 running zsh 5.9