### PR TITLE
fix(shims): exec/sh-rehash use v3-native gopath dir (Option B, #545)

### DIFF
--- a/cmd/shims/exec.go
+++ b/cmd/shims/exec.go
@@ -111,9 +111,10 @@ func runExec(cmd *cobra.Command, args []string) error {
 
 		// Set GOPATH if not disabled
 		if !env.HasDisableGopath() {
-			// Build version-specific GOPATH: $HOME/go/{version}
-			homeDir, _ := os.UserHomeDir()
-			versionGopath := filepath.Join(homeDir, "go", currentVersion)
+			// Build version-specific GOPATH: $GOENV_ROOT/versions/{version}/gopath
+			// This must match the rehash scan path (config.VersionGopathBin), so
+			// "go install" writes binaries where rehash will pick them up.
+			versionGopath := cfg.VersionGopath(currentVersion)
 
 			// Preserve existing GOPATH by prepending version-specific path.
 			// This allows users to keep source code in existing locations while

--- a/cmd/shims/exec_integration_test.go
+++ b/cmd/shims/exec_integration_test.go
@@ -80,9 +80,9 @@ func TestExec_AutoRehashAfterGoInstall(t *testing.T) {
 	// 2. Running rehash manually (simulating what exec does)
 	// 3. Verifying the shim was created
 
-	// Create a mock GOPATH for testing
-	gopath := filepath.Join(tempRoot, "go", testVersion)
-	gopathBin := filepath.Join(gopath, "bin")
+	// Create a mock GOPATH for testing (must match the v3-native layout that
+	// Rehash scans: $GOENV_ROOT/versions/{version}/gopath/bin).
+	gopathBin := cfg.VersionGopathBin(testVersion)
 	_ = utils.EnsureDirWithContext(gopathBin, "create test directory")
 
 	// Create a mock tool binary

--- a/cmd/shims/sh-rehash.go
+++ b/cmd/shims/sh-rehash.go
@@ -80,12 +80,18 @@ func runShRehash(cmd *cobra.Command, args []string) error {
 	disableGoroot := env.HasDisableGoroot()
 	disableGopath := env.HasDisableGopath()
 
-	// Build GOPATH value: $HOME/go/{version}
+	// Build GOPATH value: $GOENV_ROOT/versions/{version}/gopath
+	// This must match the rehash scan path (config.VersionGopathBin), so
+	// "go install" writes binaries where rehash will pick them up.
+	gopathValue := cfg.VersionGopath(currentVersion)
+
+	// Resolve $HOME for legacy GOPATH-filtering below. We no longer write to
+	// $HOME/go/{version}, but a user-set GOPATH may still contain stale entries
+	// from older goenv versions; strip those to prevent duplication.
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		home = os.Getenv(utils.EnvVarHome) // Fallback
 	}
-	gopathValue := filepath.Join(home, "go", currentVersion)
 
 	// Preserve existing GOPATH by prepending version-specific path.
 	// This allows users to keep source code in existing locations while

--- a/cmd/shims/sh-rehash_test.go
+++ b/cmd/shims/sh-rehash_test.go
@@ -173,10 +173,15 @@ func TestShRehashCommand(t *testing.T) {
 		cmdtest.CreateMockGoVersion(t, tmpDir, "1.12.0")
 
 		home, _ := os.UserHomeDir()
-		versionGopath := filepath.Join(home, "go", "1.12.0")
+		// Legacy v2 GOPATH layout. Option B no longer writes here, but we still
+		// strip these entries so users upgrading from v2 don't carry stale paths.
+		legacyVersionGopath := filepath.Join(home, "go", "1.12.0")
+		// What sh-rehash will now output for the version-specific GOPATH.
+		versionGopath := filepath.Join(tmpDir, "versions", "1.12.0", "gopath")
 
-		// Simulate GOPATH that already has the version-specific path (from previous init)
-		existingGopath := versionGopath + ":/existing/path1:" + versionGopath + ":/existing/path2"
+		// Simulate GOPATH that already has the legacy version-specific path (from
+		// previous init under v2). It should be filtered out of the output.
+		existingGopath := legacyVersionGopath + ":/existing/path1:" + legacyVersionGopath + ":/existing/path2"
 
 		// Set environment variables
 		os.Setenv("GOENV_VERSION", "1.12.0")
@@ -197,11 +202,13 @@ func TestShRehashCommand(t *testing.T) {
 
 		output := outputBuf.String()
 
-		// Count occurrences of the version-specific GOPATH
+		// Version-specific GOPATH (v3-native layout) should appear exactly once.
 		count := strings.Count(output, versionGopath)
-
-		// Should only appear once in the output, not multiple times
 		assert.Equal(t, 1, count, "Version-specific GOPATH should appear only once in output, got: %s", output)
+
+		// Legacy $HOME/go/<ver> entries should be filtered out entirely.
+		assert.NotContains(t, output, legacyVersionGopath,
+			"Legacy $HOME/go/<ver> entry must be stripped, got: %s", output)
 
 		// Verify both custom paths are still there
 		assert.Contains(t, output, "/existing/path1")
@@ -320,21 +327,26 @@ func TestShRehashGOPATHDuplication(t *testing.T) {
 			home, err := os.UserHomeDir()
 			require.NoError(t, err)
 
-			versionPath := filepath.Join(home, "go", tt.version)
+			// versionPath is the v3-native path that sh-rehash now writes.
+			versionPath := filepath.Join(tmpDir, "versions", tt.version, "gopath")
+			// legacyVersionPath is the v2-style path; existing GOPATH entries
+			// matching this prefix must be filtered out so users upgrading from
+			// v2 don't carry stale entries forward.
+			legacyVersionPath := filepath.Join(home, "go", tt.version)
 
 			// Set up existing GOPATH based on test case
 			var existingPath string
 			switch tt.name {
 			case "filters out duplicate goenv-managed paths on re-init":
-				existingPath = versionPath
+				existingPath = legacyVersionPath
 			case "filters triple duplication":
-				existingPath = strings.Join([]string{versionPath, versionPath, versionPath}, string(os.PathListSeparator))
+				existingPath = strings.Join([]string{legacyVersionPath, legacyVersionPath, legacyVersionPath}, string(os.PathListSeparator))
 			case "preserves custom paths while filtering duplicates":
-				existingPath = strings.Join([]string{versionPath, "/custom/path", versionPath}, string(os.PathListSeparator))
+				existingPath = strings.Join([]string{legacyVersionPath, "/custom/path", legacyVersionPath}, string(os.PathListSeparator))
 			case "preserves $HOME/go if present":
-				existingPath = strings.Join([]string{versionPath, filepath.Join(home, "go")}, string(os.PathListSeparator))
+				existingPath = strings.Join([]string{legacyVersionPath, filepath.Join(home, "go")}, string(os.PathListSeparator))
 			case "fish shell filters duplicates":
-				existingPath = versionPath
+				existingPath = legacyVersionPath
 			}
 
 			// Set environment
@@ -399,13 +411,18 @@ func TestShRehashGOPATHDuplication(t *testing.T) {
 				"%s: Expected version path to appear %d time(s), but appeared %d time(s) in GOPATH: %s",
 				tt.description, tt.expectedCount, count, gopathValue)
 
+			// Legacy $HOME/go/<ver> entries must be stripped under Option B.
+			assert.NotContains(t, pathSegments, legacyVersionPath,
+				"%s: Legacy $HOME/go/<ver> entry must be filtered, got: %s",
+				tt.description, gopathValue)
+
 			// Additional checks for specific test cases
 			switch tt.name {
 			case "preserves custom paths while filtering duplicates":
 				assert.Contains(t, gopathValue, "/custom/path",
 					"Should preserve custom path")
 			case "preserves $HOME/go if present":
-				assert.Contains(t, gopathValue, filepath.Join(home, "go"),
+				assert.Contains(t, pathSegments, filepath.Join(home, "go"),
 					"Should preserve $HOME/go")
 			}
 		})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,11 +207,18 @@ func (c *Config) VersionGoBinary(version string) string {
 	return goBinary
 }
 
+// VersionGopath returns the gopath directory for a specific version
+// This is the GOPATH that "go install" should use for version-scoped tool installs
+// Example: /Users/user/.goenv/versions/1.21.0/gopath
+func (c *Config) VersionGopath(version string) string {
+	return filepath.Join(c.VersionDir(version), "gopath")
+}
+
 // VersionGopathBin returns the gopath/bin directory for a specific version
 // This is where tools installed with "go install" are placed
 // Example: /Users/user/.goenv/versions/1.21.0/gopath/bin
 func (c *Config) VersionGopathBin(version string) string {
-	return filepath.Join(c.VersionDir(version), "gopath", "bin")
+	return filepath.Join(c.VersionGopath(version), "bin")
 }
 
 // FindVersionGoBinary returns the path to the Go binary for a specific version,


### PR DESCRIPTION
## Summary

**Option B of three** for issue #545.

Aligns `exec` and `sh-rehash` with the v3-native layout: `GOPATH` now points at `$GOENV_ROOT/versions/$version/gopath`, matching where `rehash` already scans (`config.VersionGopathBin`). Existing `~/go/$version` entries are filtered out of inherited GOPATH so users upgrading from v2 don't carry stale paths.

## Changes

- `internal/config/config.go` — adds `VersionGopath(version)` helper; `VersionGopathBin` delegates to it.
- `cmd/shims/exec.go` — replaces `filepath.Join(homeDir, "go", currentVersion)` with `cfg.VersionGopath(currentVersion)`.
- `cmd/shims/sh-rehash.go` — same swap. Keeps `home`/`goPathPattern` so legacy `~/go/$ver` entries are filtered out of any inherited `GOPATH`.
- `cmd/shims/exec_integration_test.go`, `cmd/shims/sh-rehash_test.go` — updated to assert the v3-native path and the legacy-stripping behaviour.

## Trade-offs

- **Pro:** smallest patch (5 files); aligns with the rest of v3's `versions/$ver/gopath` layout used by the `tools` subsystem.
- **Con:** **breaking for existing users.** Tools previously installed at `~/go/$version/bin` are orphaned. Users must `go install` them again under the new GOPATH (or `mv ~/go/$ver/bin/* $GOENV_ROOT/versions/$ver/gopath/bin/`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — pass
- [x] Manual smoke test: `eval "$(goenv sh-rehash)"` exports `GOPATH=$GOENV_ROOT/versions/$ver/gopath` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
