### PR TITLE
fix(shims): rehash scans both v3 and legacy gopath bin (Option C — additive, #545)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,6 +214,25 @@ func (c *Config) VersionGopathBin(version string) string {
 	return filepath.Join(c.VersionDir(version), "gopath", "bin")
 }
 
+// LegacyHomeGopathBin returns the legacy GOPATH bin directory for a specific
+// version under the user's home directory.
+//
+// This exists because the shims (cmd/shims/exec.go and cmd/shims/sh-rehash.go)
+// currently set GOPATH to "$HOME/go/{version}" when launching the Go toolchain,
+// so "go install" actually writes binaries to "$HOME/go/{version}/bin" rather
+// than to the v3-managed VersionGopathBin path. Until those shims are aligned,
+// rehash and ResolveBinary must scan this legacy location as well.
+//
+// Returns the empty string if the user's home directory cannot be determined.
+// Example: /Users/user/go/1.21.0/bin
+func (c *Config) LegacyHomeGopathBin(version string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, "go", version, "bin")
+}
+
 // FindVersionGoBinary returns the path to the Go binary for a specific version,
 // handling platform-specific executable extensions (.exe on Windows)
 // Returns an error if the binary doesn't exist

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -47,6 +47,14 @@ func (r *Resolver) ResolveBinary(command, version, versionSource string) (string
 		if path, err := utils.FindExecutable(versionGopathBin, command); err == nil {
 			return path, nil
 		}
+
+		// Also check the legacy "$HOME/go/{version}/bin" location, since the
+		// shims currently install binaries there. See LegacyHomeGopathBin doc.
+		if legacyBin := r.config.LegacyHomeGopathBin(version); legacyBin != "" {
+			if path, err := utils.FindExecutable(legacyBin, command); err == nil {
+				return path, nil
+			}
+		}
 	}
 
 	// ONLY check host bin if using global version (not project-specific)
@@ -82,6 +90,9 @@ func (r *Resolver) FindVersionsWithBinary(command string, allVersions []string) 
 
 		if !gopathDisabled {
 			dirs = append(dirs, r.config.VersionGopathBin(version))
+			if legacyBin := r.config.LegacyHomeGopathBin(version); legacyBin != "" {
+				dirs = append(dirs, legacyBin)
+			}
 		}
 
 		if _, err := pathutil.ResolveBinary(command, dirs); err == nil {
@@ -102,6 +113,12 @@ func (r *Resolver) GetBinaryDirectories(version string) []string {
 	// Add version-specific GOPATH bin if not disabled
 	if !r.env.HasDisableGopath() {
 		dirs = append(dirs, r.config.VersionGopathBin(version))
+
+		// Also include the legacy "$HOME/go/{version}/bin" location, because
+		// the shims currently install binaries there. See LegacyHomeGopathBin.
+		if legacyBin := r.config.LegacyHomeGopathBin(version); legacyBin != "" {
+			dirs = append(dirs, legacyBin)
+		}
 	}
 
 	return dirs

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1,0 +1,160 @@
+package resolver
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/go-nv/goenv/internal/config"
+	"github.com/go-nv/goenv/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeExecutable creates a file at path and (on Unix) marks it executable.
+// On Windows, it appends ".exe" to satisfy the executable-extension check.
+func writeExecutable(t *testing.T, dir, name string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	fileName := name
+	if runtime.GOOS == "windows" {
+		fileName = name + ".exe"
+	}
+	path := filepath.Join(dir, fileName)
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\necho ok\n"), 0o755))
+	return path
+}
+
+// newTestResolver builds a Resolver pointed at the given root, with GOPATH
+// enabled.
+func newTestResolver(root string) *Resolver {
+	cfg := &config.Config{Root: root}
+	env := &utils.GoenvEnvironment{}
+	return New(cfg, env)
+}
+
+// TestResolveBinary_FindsLegacyHomeGopathBin verifies that ResolveBinary picks
+// up binaries installed by the shims into "$HOME/go/{version}/bin", which is
+// the path the v3 shims actually write to today.
+func TestResolveBinary_FindsLegacyHomeGopathBin(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	root := filepath.Join(tmp, "goenv")
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	const version = "1.21.0"
+	const tool = "sometool"
+
+	legacyBinDir := filepath.Join(home, "go", version, "bin")
+	writeExecutable(t, legacyBinDir, tool)
+
+	r := newTestResolver(root)
+
+	got, err := r.ResolveBinary(tool, version, "")
+	require.NoError(t, err)
+
+	expected := filepath.Join(legacyBinDir, tool)
+	if runtime.GOOS == "windows" {
+		expected += ".exe"
+	}
+	assert.Equal(t, expected, got)
+}
+
+// TestGetBinaryDirectories_IncludesLegacyHomeGopathBin verifies that rehash
+// (via GetBinaryDirectories) scans the legacy "$HOME/go/{version}/bin" path.
+func TestGetBinaryDirectories_IncludesLegacyHomeGopathBin(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	root := filepath.Join(tmp, "goenv")
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	const version = "1.21.0"
+
+	r := newTestResolver(root)
+	dirs := r.GetBinaryDirectories(version)
+
+	legacyBinDir := filepath.Join(home, "go", version, "bin")
+	assert.Contains(t, dirs, legacyBinDir,
+		"GetBinaryDirectories should include legacy $HOME/go/{version}/bin so rehash sees shim-installed tools")
+
+	// Sanity: the v3 path should still be there too (this is the additive fix).
+	cfg := &config.Config{Root: root}
+	assert.Contains(t, dirs, cfg.VersionGopathBin(version),
+		"GetBinaryDirectories should still include the v3 VersionGopathBin")
+	assert.Contains(t, dirs, cfg.VersionBinDir(version),
+		"GetBinaryDirectories should still include VersionBinDir")
+}
+
+// TestGetBinaryDirectories_OmitsLegacyWhenGopathDisabled verifies that when
+// GOENV_DISABLE_GOPATH=true, the legacy path is NOT scanned (matching the
+// existing behaviour for VersionGopathBin).
+func TestGetBinaryDirectories_OmitsLegacyWhenGopathDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	root := filepath.Join(tmp, "goenv")
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	const version = "1.21.0"
+
+	cfg := &config.Config{Root: root}
+	env := &utils.GoenvEnvironment{DisableGopath: true}
+	r := New(cfg, env)
+
+	dirs := r.GetBinaryDirectories(version)
+
+	legacyBinDir := filepath.Join(home, "go", version, "bin")
+	assert.NotContains(t, dirs, legacyBinDir,
+		"legacy bin should not be scanned when GOPATH is disabled")
+	assert.NotContains(t, dirs, cfg.VersionGopathBin(version),
+		"version gopath bin should not be scanned when GOPATH is disabled")
+}
+
+// TestFindVersionsWithBinary_FindsLegacyHomeGopathBin verifies that
+// FindVersionsWithBinary considers the legacy "$HOME/go/{version}/bin" path.
+func TestFindVersionsWithBinary_FindsLegacyHomeGopathBin(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	root := filepath.Join(tmp, "goenv")
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	const version = "1.21.0"
+	const tool = "sometool"
+
+	writeExecutable(t, filepath.Join(home, "go", version, "bin"), tool)
+
+	r := newTestResolver(root)
+	got, err := r.FindVersionsWithBinary(tool, []string{version})
+	require.NoError(t, err)
+	assert.Equal(t, []string{version}, got)
+}
+
+// TestConfig_LegacyHomeGopathBin spot-checks the new config helper.
+func TestConfig_LegacyHomeGopathBin(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tmp)
+	}
+
+	cfg := &config.Config{Root: filepath.Join(tmp, "goenv")}
+	got := cfg.LegacyHomeGopathBin("1.21.0")
+	assert.Equal(t, filepath.Join(tmp, "go", "1.21.0", "bin"), got)
+}


### PR DESCRIPTION
## Summary

**Option C of three** for issue #545.

Strictly additive fix: resolver and rehash now consult **both** `$GOENV_ROOT/versions/$version/gopath/bin` and `$HOME/go/$version/bin`. Tools installed under either layout become shims. No behaviour is removed, no migration is needed.

## Changes

- `internal/config/config.go` — adds `LegacyHomeGopathBin(version)` returning `$HOME/go/$version/bin` (empty string on `os.UserHomeDir()` error).
- `internal/resolver/resolver.go`:
  - `ResolveBinary` checks `LegacyHomeGopathBin` after `VersionGopathBin` (when GOPATH is enabled).
  - `GetBinaryDirectories` includes the legacy path.
  - `FindVersionsWithBinary` includes the legacy path.
- `internal/resolver/resolver_test.go` (new) — 5 tests covering the new behaviour and the GOPATH-disabled negative case.

## Trade-offs

- **Pro:** zero migration. Works for v2-installed users immediately. Works for v3-native installs immediately. Smallest meaningful fix.
- **Con:** maintains two paths in perpetuity. If the same tool name exists in both directories, first-hit wins (deterministic ordering: v3 dir then legacy).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass, including 5 new resolver tests
- [x] Manual smoke test: `goenv rehash` against an environment with 32 tools in `~/go/$ver/bin` produces 38 shims (same as v2 master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
