### PR TITLE
fix(exec): deduplicate GOPATH to prevent doubling on re-entrant shim calls

### DIFF
--- a/cmd/shims/exec.go
+++ b/cmd/shims/exec.go
@@ -125,8 +125,20 @@ func runExec(cmd *cobra.Command, args []string) error {
 			// This allows users to keep source code in existing locations while
 			// giving priority to version-specific installed tools/packages.
 			// See: https://github.com/go-nv/goenv/issues/147
+			// Filter out goenv-managed paths to prevent duplication when goenv exec
+			// is called from inside an already-managed shell (e.g. a tool that
+			// shells out to `go env GOPATH` through the shim).
 			if gopath != "" {
-				versionGopath = versionGopath + string(os.PathListSeparator) + gopath
+				goPathPattern := filepath.Join(homeDir, "go")
+				var filteredPaths []string
+				for _, p := range filepath.SplitList(gopath) {
+					if !strings.HasPrefix(p, goPathPattern+string(filepath.Separator)) || p == goPathPattern {
+						filteredPaths = append(filteredPaths, p)
+					}
+				}
+				if len(filteredPaths) > 0 {
+					versionGopath = versionGopath + string(os.PathListSeparator) + strings.Join(filteredPaths, string(os.PathListSeparator))
+				}
 			}
 
 			execEnv = setEnvVar(execEnv, utils.EnvVarGopath, versionGopath)


### PR DESCRIPTION
Fixes #552

## What

`cmd/shims/exec.go` was prepending the version-specific GOPATH (`$HOME/go/{version}`) to the existing `$GOPATH` without filtering out entries already managed by goenv. When any shim-wrapped binary shells out to another shim (e.g. `gup` calling `go env GOPATH`), the version path was appended again on every re-entrant call:

```
/Users/user/go/1.26.3:/Users/user/go/1.26.3   ← doubled
```

This produces a literal colon-containing filesystem path that breaks tools like [gup](https://github.com/nao1215/gup) with:

```
open /Users/user/go/1.26.3:/Users/user/go/1.26.3/bin: no such file or directory
```

## Fix

Apply the same deduplication guard already present in `sh-rehash.go`: filter `$HOME/go/{version}` entries from the existing GOPATH before appending the non-managed remainder.

```go
// Before
if gopath != "" {
    versionGopath = versionGopath + string(os.PathListSeparator) + gopath
}

// After
if gopath != "" {
    goPathPattern := filepath.Join(homeDir, "go")
    var filteredPaths []string
    for _, p := range filepath.SplitList(gopath) {
        if !strings.HasPrefix(p, goPathPattern+string(filepath.Separator)) || p == goPathPattern {
            filteredPaths = append(filteredPaths, p)
        }
    }
    if len(filteredPaths) > 0 {
        versionGopath = versionGopath + string(os.PathListSeparator) + strings.Join(filteredPaths, string(os.PathListSeparator))
    }
}
```

## Test plan

- [ ] `go test ./cmd/shims/...` passes
- [ ] `GOPATH=$HOME/go/1.26.3 goenv exec go env GOPATH` returns a single non-doubled path
- [ ] `gup update` completes without "no such file or directory" error