### PR TITLE
fix(tools): make version optional and improve error reporting for install-vscode

### DIFF
--- a/cmd/tools/install_vscode.go
+++ b/cmd/tools/install_vscode.go
@@ -11,7 +11,7 @@ import (
 )
 
 var installVSCodeCmd = &cobra.Command{
-	Use:   "install-vscode <version>",
+	Use:   "install-vscode [version]",
 	Short: "Install VSCode Go extension tools for a Go version",
 	Long: `Installs all tools required by the VSCode Go extension for a specific Go version.
 
@@ -32,15 +32,15 @@ These tools provide the full IntelliSense, debugging, and code editing
 capabilities of the VSCode Go extension.
 
 Examples:
+  # Install VSCode tools for current version
+  goenv tools install-vscode
+
   # Install VSCode tools for specific version
   goenv tools install-vscode 1.25.2
 
-  # Install for current version
-  goenv tools install-vscode $(goenv version-name)
-
   # Show what would be installed
-  goenv tools install-vscode 1.25.2 --dry-run`,
-	Args: cobra.ExactArgs(1),
+  goenv tools install-vscode --dry-run`,
+	Args: cobra.RangeArgs(0, 1),
 	RunE: runInstallVSCode,
 }
 
@@ -58,7 +58,19 @@ func runInstallVSCode(cmd *cobra.Command, args []string) error {
 	ctx := cmdutil.GetContexts(cmd)
 	cfg := ctx.Config
 	mgr := ctx.Manager
-	goVersion := args[0]
+
+	// Get version from args or use current version
+	var goVersion string
+	if len(args) > 0 {
+		goVersion = args[0]
+	} else {
+		// Use GetCurrentVersionResolved to handle partial versions (e.g., "1.25" → "1.25.10")
+		var err error
+		goVersion, _, _, err = mgr.GetCurrentVersionResolved()
+		if err != nil {
+			return fmt.Errorf("no Go version specified and no current version set. Use 'goenv global <version>' or specify a version")
+		}
+	}
 
 	// Validate version is installed
 	if !mgr.IsVersionInstalled(goVersion) {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -199,6 +200,7 @@ func InstallTools(config *Config, goVersion string, goenvRoot string, hostGopath
 	// Track results
 	installed := []string{}
 	failed := []string{}
+	var firstError error
 
 	for _, tool := range config.Tools {
 		if verbose {
@@ -226,14 +228,37 @@ func InstallTools(config *Config, goVersion string, goenvRoot string, hostGopath
 			cmd.Env = append(cmd.Env, utils.EnvVarGomodcache+"="+sharedGomodcache)
 		}
 
-		cmd.Stdout = nil // Suppress output unless there's an error
-		cmd.Stderr = nil
+		// Capture stderr for error reporting
+		var stderr bytes.Buffer
+		if verbose {
+			// In verbose mode, show all output
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+		} else {
+			// In non-verbose mode, capture stderr for error reporting
+			cmd.Stdout = nil
+			cmd.Stderr = &stderr
+		}
 
 		if err := cmd.Run(); err != nil {
 			if verbose {
 				fmt.Printf(" %sFAILED\n", utils.Emoji("❌ "))
+			} else {
+				// Show error details in non-verbose mode
+				fmt.Printf("  %s %s: %v\n", utils.Emoji("❌"), tool.Name, err)
+				if stderr.Len() > 0 {
+					fmt.Printf("    %s\n", strings.TrimSpace(stderr.String()))
+				}
 			}
 			failed = append(failed, tool.Name)
+			// Capture first error for context
+			if firstError == nil {
+				if stderr.Len() > 0 {
+					firstError = fmt.Errorf("%s failed: %w\n%s", tool.Name, err, strings.TrimSpace(stderr.String()))
+				} else {
+					firstError = fmt.Errorf("%s failed: %w", tool.Name, err)
+				}
+			}
 		} else {
 			if verbose {
 				fmt.Printf(" %s\n", utils.Emoji("✅"))
@@ -247,6 +272,9 @@ func InstallTools(config *Config, goVersion string, goenvRoot string, hostGopath
 	}
 
 	if len(failed) > 0 {
+		if firstError != nil {
+			return fmt.Errorf("failed to install %d tool(s): %s\n\nFirst error: %w", len(failed), strings.Join(failed, ", "), firstError)
+		}
 		return fmt.Errorf("failed to install %d tool(s): %s", len(failed), strings.Join(failed, ", "))
 	}
 

--- a/internal/tools/utils.go
+++ b/internal/tools/utils.go
@@ -11,7 +11,7 @@ var commonTools = map[string]string{
 	"gomodifytags":  "github.com/fatih/gomodifytags",
 	"vscgo":         "github.com/golang/vscode-go/vscgo",
 	"goplay":        "github.com/haya14busa/goplay/cmd/goplay",
-	"gotests":       "github.com/cweill/gotests",
+	"gotests":       "github.com/cweill/gotests/gotests",
 	"gotestsum":     "gotest.tools/gotestsum",
 	"gopls":         "golang.org/x/tools/gopls",
 	"goimports":     "golang.org/x/tools/cmd/goimports",
@@ -126,11 +126,16 @@ func BuildVSCodeToolsConfig() *Config {
 	}
 
 	for _, toolName := range VSCodeTools {
-		pkg := NormalizePackagePath(toolName)
+		// Get package path without version (commonTools contains base paths only)
+		pkg := toolName
+		if fullPath, exists := commonTools[toolName]; exists {
+			pkg = fullPath
+		}
+
 		toolConfig.Tools = append(toolConfig.Tools, Tool{
 			Name:    toolName,
-			Package: pkg,
-			Version: "latest",
+			Package: pkg, // Base package path without version
+			Version: "",  // Empty - InstallTools will add @latest
 			Binary:  toolName,
 		})
 	}


### PR DESCRIPTION
## Summary

Improves the `goenv tools install-vscode` command by making the version argument optional and enhancing error reporting during tool installation.

## Changes

### User Experience Improvements
- **Optional version argument**: Now defaults to the current Go version when not specified
  - Before: `goenv tools install-vscode <version>` (required)
  - After: `goenv tools install-vscode [version]` (optional)
- **Auto-detection**: Automatically uses `GetCurrentVersionResolved()` to handle partial versions
- **Better examples**: Reorganized help text to show the most common use case first

### Error Reporting Enhancements
- **Stderr capture**: Captures and displays error output from failed tool installations
- **First error context**: Preserves the first error encountered for better debugging
- **Mode-aware output**: Respects verbose/non-verbose mode settings
  - Verbose: Shows all output in real-time
  - Non-verbose: Shows clean status with detailed errors only on failure

### Bug Fixes
- **Fixed `gotests` package path**: Corrected from `github.com/cweill/gotests` to `github.com/cweill/gotests/gotests`

## Testing

Manually tested:
- ✅ Installation with explicit version: `goenv tools install-vscode 1.25.2`
- ✅ Installation with current version: `goenv tools install-vscode`
- ✅ Error handling when no version is set
- ✅ Error reporting for failed tool installations
- ✅ Verbose and non-verbose output modes

## Example Usage

```bash
# Install VSCode tools for current version (new!)
goenv tools install-vscode

# Install VSCode tools for specific version
goenv tools install-vscode 1.25.2

# Show what would be installed
goenv tools install-vscode --dry-run
```

## Related Issues

This PR improves the usability of the VS Code integration by reducing friction in the most common use case (installing tools for the current version).