### PR TITLE
fix(tools): update golangci-lint to v2 import path

### DIFF
--- a/cmd/tools/install_tools_test.go
+++ b/cmd/tools/install_tools_test.go
@@ -151,7 +151,7 @@ func TestExtractToolNames(t *testing.T) {
 		},
 		{
 			name:     "package without version",
-			packages: []string{"github.com/golangci/golangci-lint/cmd/golangci-lint"},
+			packages: []string{"github.com/golangci/golangci-lint/v2/cmd/golangci-lint"},
 			expected: []string{"golangci-lint"},
 		},
 	}
@@ -233,7 +233,7 @@ func TestExtractToolName_ComplexPaths(t *testing.T) {
 			expected:    "gopls",
 		},
 		{
-			packagePath: "github.com/golangci/golangci-lint/cmd/golangci-lint@latest",
+			packagePath: "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest",
 			expected:    "golangci-lint",
 		},
 		{

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -90,7 +90,7 @@ func DefaultConfig() *Config {
 			},
 			{
 				Name:           "golangci-lint",
-				Package:        "github.com/golangci/golangci-lint/cmd/golangci-lint",
+				Package:        "github.com/golangci/golangci-lint/v2/cmd/golangci-lint",
 				Version:        "@latest",
 				Binary:         "golangci-lint",
 				UpdateStrategy: "auto", // Use stable versions

--- a/internal/tools/utils.go
+++ b/internal/tools/utils.go
@@ -15,7 +15,7 @@ var commonTools = map[string]string{
 	"gotestsum":     "gotest.tools/gotestsum",
 	"gopls":         "golang.org/x/tools/gopls",
 	"goimports":     "golang.org/x/tools/cmd/goimports",
-	"golangci-lint": "github.com/golangci/golangci-lint/cmd/golangci-lint",
+	"golangci-lint": "github.com/golangci/golangci-lint/v2/cmd/golangci-lint",
 	"staticcheck":   "honnef.co/go/tools/cmd/staticcheck",
 	"dlv":           "github.com/go-delve/delve/cmd/dlv",
 	"gofumpt":       "mvdan.cc/gofumpt",


### PR DESCRIPTION
## Summary

golangci-lint v2 changed its module path. The v1 path (`/cmd/golangci-lint`) no longer resolves, so `goenv tools install golangci-lint` fails with a module not found error.

| | Path |
|---|---|
| **Before** | `github.com/golangci/golangci-lint/cmd/golangci-lint` |
| **After** | `github.com/golangci/golangci-lint/v2/cmd/golangci-lint` |

## Files changed

- `internal/tools/tools.go` — `DefaultConfig()` tool definition
- `internal/tools/utils.go` — `commonTools` lookup map
- `cmd/tools/install_tools_test.go` — two test cases that hardcode the path (the extracted binary name `golangci-lint` is unchanged, so tests still pass)

## Test plan

- [x] `go test ./cmd/tools/... ./internal/tools/... -run TestExtractTool` passes
- [x] `goenv tools install golangci-lint` resolves to the v2 binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)