### PR TITLE
fix: prevent false positive recursion detection in tests (Fixes #564)

### DIFF
--- a/cmd/shims/exec.go
+++ b/cmd/shims/exec.go
@@ -63,9 +63,13 @@ func runExec(cmd *cobra.Command, args []string) error {
 		args = args[1:]
 	}
 
-	// Recursion guard: detect if we're being called from a shim that we spawned
+	// Recursion guard: detect if we're being called from a shim that we spawned.
+	// We only treat this as recursion if the value equals our parent PID, indicating
+	// we were spawned by another goenv exec (shim → exec → shim → exec).
+	// This avoids false positives when running tests under goenv-managed Go.
 	const recursionEnvVar = "_GOENV_EXEC_ACTIVE"
-	if os.Getenv(recursionEnvVar) != "" {
+	parentPIDStr := fmt.Sprintf("%d", os.Getppid())
+	if os.Getenv(recursionEnvVar) == parentPIDStr {
 		return fmt.Errorf("goenv: infinite recursion detected — shim is calling goenv exec again. Run 'goenv rehash' to regenerate shims")
 	}
 
@@ -312,8 +316,9 @@ func runExec(cmd *cobra.Command, args []string) error {
 	}
 
 	// Execute with the modified environment
-	// Set recursion guard so shims don't re-enter goenv exec
-	execEnv = setEnvVar(execEnv, recursionEnvVar, "1")
+	// Set recursion guard so shims don't re-enter goenv exec.
+	// Use our PID as the value so the child can detect if it's being called recursively.
+	execEnv = setEnvVar(execEnv, recursionEnvVar, fmt.Sprintf("%d", os.Getpid()))
 	execCmd := exec.Command(commandPath, commandArgs...)
 	execCmd.Env = execEnv
 	execCmd.Stdin = os.Stdin

--- a/cmd/shims/exec_test.go
+++ b/cmd/shims/exec_test.go
@@ -108,6 +108,10 @@ func TestExecCommand(t *testing.T) {
 			t.Setenv(utils.GoenvEnvVarVersion.String(), "")
 			os.Unsetenv("GOENV_VERSION")
 
+			// Clear _GOENV_EXEC_ACTIVE to avoid false recursion detection
+			// This can be set when tests are run via goenv-managed Go (e.g., during package builds)
+			os.Unsetenv("_GOENV_EXEC_ACTIVE")
+
 			// Setup test versions
 			for _, version := range tt.setupVersions {
 				cmdtest.CreateTestVersion(t, testRoot, version)


### PR DESCRIPTION
## Problem

When building the goenv AUR package on Arch Linux with goenv-installed Go (not system Go), all `exec` tests fail with:
```
goenv: infinite recursion detected — shim is calling goenv exec again. Run 'goenv rehash' to regenerate shims
```

This breaks the AUR package build because `make check` fails during testing.

## Root Cause

The recursion guard used a simple boolean check:
```go
if os.Getenv("_GOENV_EXEC_ACTIVE") != "" {
    return fmt.Errorf("goenv: infinite recursion detected...")
}
```

This created **false positives** when tests run under goenv-managed Go:

1. User has goenv Go active (e.g., 1.23.12)
2. User runs `paru -S goenv` to build AUR package
3. Build runs `make check` → `go test ./...`
4. Tests call `goenv exec` internally
5. The `_GOENV_EXEC_ACTIVE=1` env var is **inherited** from parent shell
6. Boolean check triggers → FALSE POSITIVE ❌

The issue only occurs when using goenv-managed Go because the environment already has the flag set. With system Go, the flag is not present.

## Solution

Changed from **boolean detection** to **PID-based detection**:

```go
const recursionEnvVar = "_GOENV_EXEC_ACTIVE"
parentPIDStr := fmt.Sprintf("%d", os.Getppid())
if os.Getenv(recursionEnvVar) == parentPIDStr {
    return fmt.Errorf("goenv: infinite recursion detected...")
}

// Later, when setting the guard:
execEnv = setEnvVar(execEnv, recursionEnvVar, fmt.Sprintf("%d", os.Getpid()))
```

**How it works:**
- Each `goenv exec` sets `_GOENV_EXEC_ACTIVE=<its_own_PID>`
- Child process checks if value equals **parent PID** (os.Getppid())
- Recursion only detected if parent was `goenv exec` with matching PID
- Prevents false positives from inherited environment variables ✅

Also added defensive cleanup in test setup:
```go
os.Unsetenv("_GOENV_EXEC_ACTIVE")
```

## Testing

✅ All exec tests now pass:
- `TestExecCommand` (9 subtests)
- `TestExecEnvironmentVariables`
- `TestExecWithShims`

The PID-based approach:
- ✅ Prevents false positives when tests run under goenv-managed Go
- ✅ Still catches real infinite recursion (shim → exec → shim → exec chain)
- ✅ Allows AUR package builds to complete successfully

## Related Issues

Fixes #564

## Checklist

- [x] Tests pass locally
- [x] Fix prevents false positives
- [x] Real recursion still detected
- [x] Commit message follows conventional commits